### PR TITLE
chore(deps): move dvc[s3] to dev group in template experiment

### DIFF
--- a/experiments/template/pyproject.toml
+++ b/experiments/template/pyproject.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 description = "Experiment template"
 requires-python = ">=3.11"
 dependencies = [
-    "dvc[s3]>=3.56",
     "pyrocore @ file:///${PROJECT_ROOT}/../../lib/pyrocore",
 ]
 
 [dependency-groups]
 dev = [
+    "dvc[s3]>=3.56",
     "nbqa>=1.9",
     "nbstripout>=0.8",
     "pytest>=8.0",

--- a/experiments/template/uv.lock
+++ b/experiments/template/uv.lock
@@ -1630,12 +1630,12 @@ name = "project-name"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "dvc", extra = ["s3"] },
     { name = "pyrocore" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "dvc", extra = ["s3"] },
     { name = "nbqa" },
     { name = "nbstripout" },
     { name = "pytest" },
@@ -1643,13 +1643,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "dvc", extras = ["s3"], specifier = ">=3.56" },
-    { name = "pyrocore", directory = "../../lib/pyrocore" },
-]
+requires-dist = [{ name = "pyrocore", directory = "../../lib/pyrocore" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "dvc", extras = ["s3"], specifier = ">=3.56" },
     { name = "nbqa", specifier = ">=1.9" },
     { name = "nbstripout", specifier = ">=0.8" },
     { name = "pytest", specifier = ">=8.0" },


### PR DESCRIPTION
## Summary
- Move `dvc[s3]` from main `dependencies` to the `dev` dependency group in the template experiment
- DVC is a CLI orchestration tool, never imported in Python code — it belongs with dev tooling
- Aligns template with tracking-fsm-baseline which already has this correct

## Test plan
- [x] `uv sync` resolves successfully in `experiments/template/`