### PR TITLE
docs: update pyrocore README to use uv sources dependency pattern

### DIFF
--- a/lib/pyrocore/README.md
+++ b/lib/pyrocore/README.md
@@ -13,10 +13,16 @@ Shared types and base model for Pyronear temporal smoke detection experiments.
 Experiments add pyrocore as a path dependency in their `pyproject.toml`:
 
 ```toml
+[project]
 dependencies = [
-    "pyrocore @ file:///${PROJECT_ROOT}/../../lib/pyrocore",
+    "pyrocore",
 ]
+
+[tool.uv.sources]
+pyrocore = { path = "../../../lib/pyrocore" }
 ```
+
+Adjust the relative path depth based on the experiment's nesting level.
 
 Then subclass `TemporalModel` and implement `predict`:
 


### PR DESCRIPTION
## Summary
- Update the pyrocore README usage section to reflect the current `[tool.uv.sources]` dependency pattern instead of the old `file:///${PROJECT_ROOT}` inline syntax

## Test plan
- [x] Verify the README renders correctly on GitHub