### PR TITLE
Add bbox-tube-temporal to temporal-model leaderboard

### DIFF
--- a/experiments/temporal-models/bbox-tube-temporal/data/06_models/vit_dinov2_finetune/.gitignore
+++ b/experiments/temporal-models/bbox-tube-temporal/data/06_models/vit_dinov2_finetune/.gitignore
@@ -1,2 +1,3 @@
 /best_checkpoint.pt
 /csv_logs
+/model.zip

--- a/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru/.gitignore
+++ b/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru/.gitignore
@@ -1,1 +1,0 @@
-/training_curves.png

--- a/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_convnext/.gitignore
+++ b/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_convnext/.gitignore
@@ -1,1 +1,0 @@
-/training_curves.png

--- a/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_convnext_finetune/.gitignore
+++ b/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_convnext_finetune/.gitignore
@@ -1,1 +1,0 @@
-/training_curves.png

--- a/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_finetune/.gitignore
+++ b/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_finetune/.gitignore
@@ -1,1 +1,0 @@
-/training_curves.png

--- a/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_seed43/.gitignore
+++ b/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_seed43/.gitignore
@@ -1,1 +1,0 @@
-/training_curves.png

--- a/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_seed44/.gitignore
+++ b/experiments/temporal-models/bbox-tube-temporal/data/08_reporting/training/gru_seed44/.gitignore
@@ -1,1 +1,0 @@
-/training_curves.png

--- a/experiments/temporal-models/bbox-tube-temporal/dvc.lock
+++ b/experiments/temporal-models/bbox-tube-temporal/dvc.lock
@@ -2621,8 +2621,8 @@ stages:
       md5: e579f7492abf75c9671b89accfc93b10
       size: 27257
   package:
-    cmd: uv run python scripts/package_model.py --variant gru_convnext_finetune 
-      --output data/06_models/gru_convnext_finetune/model.zip
+    cmd: uv run python scripts/package_model.py --variant vit_dinov2_finetune 
+      --output data/06_models/vit_dinov2_finetune/model.zip
     deps:
     - path: data/01_raw/models/best.pt
       hash: md5
@@ -2633,22 +2633,22 @@ stages:
       md5: e662d34ba87b486399cbb444f0b3a1d2.dir
       size: 89476209
       nfiles: 3645
-    - path: data/06_models/gru_convnext_finetune/best_checkpoint.pt
+    - path: data/06_models/vit_dinov2_finetune/best_checkpoint.pt
       hash: md5
-      md5: 85ccbf61d9c7257c9571bd96b9b3e16c
-      size: 239501727
+      md5: 731a3f78bcf2524009b79342b6505d2b
+      size: 143537003
     - path: scripts/package_model.py
       hash: md5
-      md5: 81a1c3392b3cd522a02c92a44bcd94d0
-      size: 5251
+      md5: 06a0202901e0cc5d7973b21897834238
+      size: 5692
     - path: src/bbox_tube_temporal/calibration.py
       hash: md5
       md5: 2303307ff3b86f1186582f9db6982163
       size: 1811
     - path: src/bbox_tube_temporal/package.py
       hash: md5
-      md5: 3bdb44e7c65a2dd962e2b97026a3d0c2
-      size: 6704
+      md5: d7d0c9620433618b5cda5cbf06cdffe7
+      size: 7795
     - path: src/bbox_tube_temporal/val_predict.py
       hash: md5
       md5: 30716090646cf21c42dff4fd6f501a08
@@ -2668,20 +2668,26 @@ stages:
             confidence_threshold: 0.01
             iou_nms: 0.2
             image_size: 1024
-        train_gru_convnext_finetune:
+        train_vit_dinov2_finetune:
           hidden_dim: 128
           max_frames: 20
-          batch_size: 32
+          batch_size: 16
           num_workers: 4
-          learning_rate: 0.001
-          weight_decay: 0.01
+          learning_rate: 0.0001
+          weight_decay: 0.05
           max_epochs: 30
           early_stop_patience: 5
           seed: 42
-          arch: gru
-          backbone: convnext_tiny
-          num_layers: 1
-          bidirectional: false
+          arch: transformer
+          global_pool: token
+          img_size: 224
+          transformer_num_layers: 2
+          transformer_num_heads: 6
+          transformer_ffn_dim: 1536
+          transformer_dropout: 0.1
+          use_cosine_warmup: true
+          warmup_frac: 0.05
+          backbone: vit_small_patch14_dinov2.lvd142m
           finetune: true
           finetune_last_n_blocks: 1
           backbone_lr: 1e-05
@@ -2689,10 +2695,10 @@ stages:
           iou_threshold: 0.2
           max_misses: 2
     outs:
-    - path: data/06_models/gru_convnext_finetune/model.zip
+    - path: data/06_models/vit_dinov2_finetune/model.zip
       hash: md5
-      md5: 4eb39dd29edf3dcd3ea3d78796bc776b
-      size: 258728562
+      md5: f6a972c7d14d0bdf1afc527e7d106a02
+      size: 162764055
   train_vit_dinov2_frozen:
     cmd: uv run python scripts/train.py --arch transformer --train-dir 
       data/05_model_input/train --val-dir data/05_model_input/val --output-dir 

--- a/experiments/temporal-models/bbox-tube-temporal/dvc.lock
+++ b/experiments/temporal-models/bbox-tube-temporal/dvc.lock
@@ -3569,3 +3569,155 @@ stages:
       hash: md5
       md5: 96e98e294961744a9dcab50b24193cb3
       size: 27309
+  package@gru_convnext_finetune:
+    cmd: uv run python scripts/package_model.py --variant gru_convnext_finetune 
+      --output data/06_models/gru_convnext_finetune/model.zip
+    deps:
+    - path: data/01_raw/models/best.pt
+      hash: md5
+      md5: fea4ddc8d904fcc5ff11ad900e040837
+      size: 19225626
+    - path: data/05_model_input/val
+      hash: md5
+      md5: e662d34ba87b486399cbb444f0b3a1d2.dir
+      size: 89476209
+      nfiles: 3645
+    - path: data/06_models/gru_convnext_finetune/best_checkpoint.pt
+      hash: md5
+      md5: 85ccbf61d9c7257c9571bd96b9b3e16c
+      size: 239501727
+    - path: scripts/package_model.py
+      hash: md5
+      md5: 06a0202901e0cc5d7973b21897834238
+      size: 5692
+    - path: src/bbox_tube_temporal/calibration.py
+      hash: md5
+      md5: 2303307ff3b86f1186582f9db6982163
+      size: 1811
+    - path: src/bbox_tube_temporal/package.py
+      hash: md5
+      md5: d7d0c9620433618b5cda5cbf06cdffe7
+      size: 7795
+    - path: src/bbox_tube_temporal/val_predict.py
+      hash: md5
+      md5: 30716090646cf21c42dff4fd6f501a08
+      size: 1974
+    params:
+      params.yaml:
+        build_tubes:
+          min_tube_length: 4
+          min_detected_entries: 2
+        model_input:
+          context_factor: 1.5
+          patch_size: 224
+        package:
+          target_recall: 0.95
+          infer_min_tube_length: 2
+          infer:
+            confidence_threshold: 0.01
+            iou_nms: 0.2
+            image_size: 1024
+        train_gru_convnext_finetune:
+          hidden_dim: 128
+          max_frames: 20
+          batch_size: 32
+          num_workers: 4
+          learning_rate: 0.001
+          weight_decay: 0.01
+          max_epochs: 30
+          early_stop_patience: 5
+          seed: 42
+          arch: gru
+          backbone: convnext_tiny
+          num_layers: 1
+          bidirectional: false
+          finetune: true
+          finetune_last_n_blocks: 1
+          backbone_lr: 1e-05
+        tubes:
+          iou_threshold: 0.2
+          max_misses: 2
+    outs:
+    - path: data/06_models/gru_convnext_finetune/model.zip
+      hash: md5
+      md5: e651122c7807c7f9fd113423e5ea8f4e
+      size: 258728626
+  package@vit_dinov2_finetune:
+    cmd: uv run python scripts/package_model.py --variant vit_dinov2_finetune 
+      --output data/06_models/vit_dinov2_finetune/model.zip
+    deps:
+    - path: data/01_raw/models/best.pt
+      hash: md5
+      md5: fea4ddc8d904fcc5ff11ad900e040837
+      size: 19225626
+    - path: data/05_model_input/val
+      hash: md5
+      md5: e662d34ba87b486399cbb444f0b3a1d2.dir
+      size: 89476209
+      nfiles: 3645
+    - path: data/06_models/vit_dinov2_finetune/best_checkpoint.pt
+      hash: md5
+      md5: 731a3f78bcf2524009b79342b6505d2b
+      size: 143537003
+    - path: scripts/package_model.py
+      hash: md5
+      md5: 06a0202901e0cc5d7973b21897834238
+      size: 5692
+    - path: src/bbox_tube_temporal/calibration.py
+      hash: md5
+      md5: 2303307ff3b86f1186582f9db6982163
+      size: 1811
+    - path: src/bbox_tube_temporal/package.py
+      hash: md5
+      md5: d7d0c9620433618b5cda5cbf06cdffe7
+      size: 7795
+    - path: src/bbox_tube_temporal/val_predict.py
+      hash: md5
+      md5: 30716090646cf21c42dff4fd6f501a08
+      size: 1974
+    params:
+      params.yaml:
+        build_tubes:
+          min_tube_length: 4
+          min_detected_entries: 2
+        model_input:
+          context_factor: 1.5
+          patch_size: 224
+        package:
+          target_recall: 0.95
+          infer_min_tube_length: 2
+          infer:
+            confidence_threshold: 0.01
+            iou_nms: 0.2
+            image_size: 1024
+        train_vit_dinov2_finetune:
+          hidden_dim: 128
+          max_frames: 20
+          batch_size: 16
+          num_workers: 4
+          learning_rate: 0.0001
+          weight_decay: 0.05
+          max_epochs: 30
+          early_stop_patience: 5
+          seed: 42
+          arch: transformer
+          global_pool: token
+          img_size: 224
+          transformer_num_layers: 2
+          transformer_num_heads: 6
+          transformer_ffn_dim: 1536
+          transformer_dropout: 0.1
+          use_cosine_warmup: true
+          warmup_frac: 0.05
+          backbone: vit_small_patch14_dinov2.lvd142m
+          finetune: true
+          finetune_last_n_blocks: 1
+          backbone_lr: 1e-05
+        tubes:
+          iou_threshold: 0.2
+          max_misses: 2
+    outs:
+    - path: data/06_models/vit_dinov2_finetune/model.zip
+      hash: md5
+      md5: f6a972c7d14d0bdf1afc527e7d106a02
+      size: 162764055

--- a/experiments/temporal-models/bbox-tube-temporal/dvc.yaml
+++ b/experiments/temporal-models/bbox-tube-temporal/dvc.yaml
@@ -663,10 +663,10 @@ stages:
   package:
     cmd: >-
       uv run python scripts/package_model.py
-      --variant gru_convnext_finetune
-      --output data/06_models/gru_convnext_finetune/model.zip
+      --variant vit_dinov2_finetune
+      --output data/06_models/vit_dinov2_finetune/model.zip
     deps:
-      - data/06_models/gru_convnext_finetune/best_checkpoint.pt
+      - data/06_models/vit_dinov2_finetune/best_checkpoint.pt
       - data/01_raw/models/best.pt
       - data/05_model_input/val
       - scripts/package_model.py
@@ -678,9 +678,9 @@ stages:
       - tubes
       - build_tubes
       - model_input
-      - train_gru_convnext_finetune
+      - train_vit_dinov2_finetune
     outs:
-      - data/06_models/gru_convnext_finetune/model.zip
+      - data/06_models/vit_dinov2_finetune/model.zip
 
   compare_variants:
     cmd: >-

--- a/experiments/temporal-models/bbox-tube-temporal/dvc.yaml
+++ b/experiments/temporal-models/bbox-tube-temporal/dvc.yaml
@@ -661,26 +661,30 @@ stages:
         - data/08_reporting/${item}/vit_in21k_finetune/confusion_matrix_normalized.png
 
   package:
-    cmd: >-
-      uv run python scripts/package_model.py
-      --variant vit_dinov2_finetune
-      --output data/06_models/vit_dinov2_finetune/model.zip
-    deps:
-      - data/06_models/vit_dinov2_finetune/best_checkpoint.pt
-      - data/01_raw/models/best.pt
-      - data/05_model_input/val
-      - scripts/package_model.py
-      - src/bbox_tube_temporal/package.py
-      - src/bbox_tube_temporal/calibration.py
-      - src/bbox_tube_temporal/val_predict.py
-    params:
-      - package
-      - tubes
-      - build_tubes
-      - model_input
-      - train_vit_dinov2_finetune
-    outs:
-      - data/06_models/vit_dinov2_finetune/model.zip
+    foreach:
+      - gru_convnext_finetune
+      - vit_dinov2_finetune
+    do:
+      cmd: >-
+        uv run python scripts/package_model.py
+        --variant ${item}
+        --output data/06_models/${item}/model.zip
+      deps:
+        - data/06_models/${item}/best_checkpoint.pt
+        - data/01_raw/models/best.pt
+        - data/05_model_input/val
+        - scripts/package_model.py
+        - src/bbox_tube_temporal/package.py
+        - src/bbox_tube_temporal/calibration.py
+        - src/bbox_tube_temporal/val_predict.py
+      params:
+        - package
+        - tubes
+        - build_tubes
+        - model_input
+        - train_${item}
+      outs:
+        - data/06_models/${item}/model.zip
 
   compare_variants:
     cmd: >-

--- a/experiments/temporal-models/bbox-tube-temporal/scripts/package_model.py
+++ b/experiments/temporal-models/bbox-tube-temporal/scripts/package_model.py
@@ -18,17 +18,40 @@ from bbox_tube_temporal.temporal_classifier import TemporalSmokeClassifier
 from bbox_tube_temporal.val_predict import collect_val_probabilities
 
 
+def _classifier_kwargs(cfg: dict) -> dict:
+    """Pick the subset of *cfg* that TemporalSmokeClassifier accepts.
+
+    Works for both params.yaml variant blocks and packaged config["classifier"]
+    dicts — each key falls back to the classifier's own default when absent.
+    """
+    kwargs: dict = {
+        "backbone": cfg["backbone"],
+        "arch": cfg["arch"],
+        "hidden_dim": cfg["hidden_dim"],
+        "pretrained": False,
+        "num_layers": cfg.get("num_layers", 1),
+        "bidirectional": cfg.get("bidirectional", False),
+        "finetune": cfg.get("finetune", False),
+        "finetune_last_n_blocks": cfg.get("finetune_last_n_blocks", 0),
+        "max_frames": cfg.get("max_frames", 20),
+        "global_pool": cfg.get("global_pool", "avg"),
+    }
+    for k in (
+        "transformer_num_layers",
+        "transformer_num_heads",
+        "transformer_ffn_dim",
+        "transformer_dropout",
+        "img_size",
+    ):
+        if k in cfg:
+            kwargs[k] = cfg[k]
+    return kwargs
+
+
 def _load_classifier_from_ckpt(
     ckpt_path: Path, variant_cfg: dict
 ) -> TemporalSmokeClassifier:
-    model = TemporalSmokeClassifier(
-        backbone=variant_cfg["backbone"],
-        arch=variant_cfg["arch"],
-        hidden_dim=variant_cfg["hidden_dim"],
-        pretrained=False,
-        num_layers=variant_cfg.get("num_layers", 1),
-        bidirectional=variant_cfg.get("bidirectional", False),
-    )
+    model = TemporalSmokeClassifier(**_classifier_kwargs(variant_cfg))
     blob = torch.load(ckpt_path, map_location="cpu", weights_only=False)
     if isinstance(blob, dict) and "state_dict" in blob:
         raw = blob["state_dict"]
@@ -63,15 +86,7 @@ def _build_config(
                 "std": [0.229, 0.224, 0.225],
             },
         },
-        "classifier": {
-            "backbone": variant_cfg["backbone"],
-            "arch": variant_cfg["arch"],
-            "hidden_dim": variant_cfg["hidden_dim"],
-            "num_layers": variant_cfg.get("num_layers", 1),
-            "bidirectional": variant_cfg.get("bidirectional", False),
-            "max_frames": variant_cfg["max_frames"],
-            "pretrained": False,
-        },
+        "classifier": _classifier_kwargs(variant_cfg),
         "decision": {
             "aggregation": "max_logit",
             "threshold": float(threshold),

--- a/experiments/temporal-models/bbox-tube-temporal/src/bbox_tube_temporal/inference.py
+++ b/experiments/temporal-models/bbox-tube-temporal/src/bbox_tube_temporal/inference.py
@@ -25,6 +25,7 @@ def run_yolo_on_frames(
     confidence_threshold: float,
     iou_nms: float,
     image_size: int,
+    device: str | torch.device | None = None,
 ) -> list[FrameDetections]:
     """Run YOLO once over all frames in a single batched call.
 
@@ -35,6 +36,8 @@ def run_yolo_on_frames(
         confidence_threshold: Minimum detection confidence.
         iou_nms: IoU threshold for YOLO's internal NMS.
         image_size: Inference resolution passed to YOLO.
+        device: Torch device for YOLO inference. ``None`` lets ultralytics
+            auto-pick (defaults to CPU).
 
     Returns:
         One :class:`FrameDetections` per input frame (possibly with zero
@@ -44,13 +47,15 @@ def run_yolo_on_frames(
         return []
 
     paths = [str(f.image_path) for f in frames]
-    results = yolo_model.predict(
-        paths,
+    predict_kwargs: dict[str, Any] = dict(
         conf=confidence_threshold,
         iou=iou_nms,
         imgsz=image_size,
         verbose=False,
     )
+    if device is not None:
+        predict_kwargs["device"] = str(device)
+    results = yolo_model.predict(paths, **predict_kwargs)
 
     out: list[FrameDetections] = []
     for idx, (frame, pred) in enumerate(zip(frames, results, strict=True)):

--- a/experiments/temporal-models/bbox-tube-temporal/src/bbox_tube_temporal/model.py
+++ b/experiments/temporal-models/bbox-tube-temporal/src/bbox_tube_temporal/model.py
@@ -110,6 +110,7 @@ class BboxTubeTemporalModel(TemporalModel):
             confidence_threshold=infer["confidence_threshold"],
             iou_nms=infer["iou_nms"],
             image_size=infer["image_size"],
+            device=self._device,
         )
         num_dets_per_frame = [len(fd.detections) for fd in frame_dets]
 

--- a/experiments/temporal-models/bbox-tube-temporal/src/bbox_tube_temporal/package.py
+++ b/experiments/temporal-models/bbox-tube-temporal/src/bbox_tube_temporal/package.py
@@ -117,6 +117,38 @@ def _load_yolo(weights_path: Path) -> Any:
     return YOLO(str(weights_path))
 
 
+def _build_classifier(classifier_cfg: dict[str, Any]) -> TemporalSmokeClassifier:
+    """Instantiate a ``TemporalSmokeClassifier`` from a packaged config block.
+
+    Mirrors the classifier kwargs written by ``scripts/package_model.py`` —
+    the packaged ``config["classifier"]`` dict carries every kwarg needed to
+    reconstruct the exact training-time architecture (including ViT-specific
+    ``global_pool``/``img_size`` and transformer-head hyperparameters).
+    """
+    kwargs: dict[str, Any] = {
+        "backbone": classifier_cfg["backbone"],
+        "arch": classifier_cfg["arch"],
+        "hidden_dim": classifier_cfg["hidden_dim"],
+        "pretrained": classifier_cfg.get("pretrained", False),
+        "num_layers": classifier_cfg.get("num_layers", 1),
+        "bidirectional": classifier_cfg.get("bidirectional", False),
+        "finetune": classifier_cfg.get("finetune", False),
+        "finetune_last_n_blocks": classifier_cfg.get("finetune_last_n_blocks", 0),
+        "max_frames": classifier_cfg.get("max_frames", 20),
+        "global_pool": classifier_cfg.get("global_pool", "avg"),
+    }
+    for k in (
+        "transformer_num_layers",
+        "transformer_num_heads",
+        "transformer_ffn_dim",
+        "transformer_dropout",
+        "img_size",
+    ):
+        if k in classifier_cfg:
+            kwargs[k] = classifier_cfg[k]
+    return TemporalSmokeClassifier(**kwargs)
+
+
 def _load_classifier(
     ckpt_path: Path, classifier_cfg: dict[str, Any]
 ) -> TemporalSmokeClassifier:
@@ -125,14 +157,7 @@ def _load_classifier(
     Accepts both Lightning-style ckpts (``{"state_dict": {"model.xxx": ...}}``)
     and plain state_dicts (``{"xxx": ...}``).
     """
-    model = TemporalSmokeClassifier(
-        backbone=classifier_cfg["backbone"],
-        arch=classifier_cfg["arch"],
-        hidden_dim=classifier_cfg["hidden_dim"],
-        pretrained=classifier_cfg.get("pretrained", False),
-        num_layers=classifier_cfg.get("num_layers", 1),
-        bidirectional=classifier_cfg.get("bidirectional", False),
-    )
+    model = _build_classifier(classifier_cfg)
     blob = torch.load(ckpt_path, map_location="cpu", weights_only=False)
     if isinstance(blob, dict) and "state_dict" in blob:
         raw = blob["state_dict"]

--- a/experiments/temporal-models/temporal-model-leaderboard/README.md
+++ b/experiments/temporal-models/temporal-model-leaderboard/README.md
@@ -8,9 +8,10 @@ Standardized evaluation and ranking of `TemporalModel` implementations on the [p
 |------|-------|-----------|--------|----|-----|--------------|----------------|
 | 1 | [FSM Tracking Baseline](../tracking-fsm-baseline/) | 0.9474 | 0.9664 | 0.9568 | 0.0537 | 142.0 | 58.0 |
 | 2 | [Pyro-Detector Baseline](../pyro-detector-baseline/) | 0.8563 | 0.9597 | 0.9051 | 0.1611 | 27.0 | 7.0 |
-| 3 | [MTB Change Detection](../mtb-change-detection/) | 0.7165 | 0.9329 | 0.8105 | 0.3691 | 85.4 | 25.0 |
+| 3 | [Bbox-Tube Temporal](../bbox-tube-temporal/) | 0.8136 | 0.9664 | 0.8834 | 0.2215 | 503.1 | 328.5 |
+| 4 | [MTB Change Detection](../mtb-change-detection/) | 0.7165 | 0.9329 | 0.8105 | 0.3691 | 85.4 | 25.0 |
 
-*Evaluated on 298 sequences (149 wildfire + 149 false positive). Last updated: 2026-04-02.*
+*Evaluated on 298 sequences (149 wildfire + 149 false positive). Last updated: 2026-04-16.*
 
 ## 🤖 Models
 
@@ -19,6 +20,7 @@ Standardized evaluation and ranking of `TemporalModel` implementations on the [p
 | [FSM Tracking Baseline](../tracking-fsm-baseline/) | [YOLO11s `nimble-narwhal` v6.0.0](https://huggingface.co/pyronear/yolo11s_nimble-narwhal_v6.0.0) + IoU-based FSM tracker. Requires temporal persistence (5 consecutive frames) before raising an alarm. Rule-based, no ML training. | [FLAME (Gragnaniello et al., 2024)](https://doi.org/10.1007/s00521-024-10963-z) |
 | [Pyro-Detector Baseline](../pyro-detector-baseline/) | Production pyro-predictor: [YOLO11s ONNX `nimble-narwhal` v6.0.0](https://huggingface.co/pyronear/yolo11s_nimble-narwhal_v6.0.0) + per-camera sliding-window temporal smoothing. Alarm when aggregated confidence crosses threshold over N consecutive frames. | -- |
 | [MTB Change Detection](../mtb-change-detection/) | [YOLO11s `nimble-narwhal` v6.0.0](https://huggingface.co/pyronear/yolo11s_nimble-narwhal_v6.0.0) + pixel-wise frame differencing (MTB ratio) to reject static FPs, followed by IoU-based FSM tracker. | [SlowFastMTB (Choi, Kim & Oh, 2022)](https://doi.org/10.3390/s22155602) |
+| [Bbox-Tube Temporal](../bbox-tube-temporal/) | YOLO11s companion + bbox-tube builder (IoU matching over ≤20 frames) + ViT-S/14 DINOv2 feature extractor with a transformer temporal head. Binary tube-level classifier with threshold calibrated to val recall=0.95. | -- |
 
 ## 📏 Metrics
 

--- a/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/.gitignore
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/.gitignore
@@ -1,4 +1,5 @@
 /fsm-tracking-baseline.zip
 /mtb-change-detection.zip
 /pyro-detector-baseline.zip
-/bbox-tube-temporal.zip
+/bbox-tube-temporal-vit-dinov2-finetune.zip
+/bbox-tube-temporal-gru-convnext-finetune.zip

--- a/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/.gitignore
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/.gitignore
@@ -1,3 +1,4 @@
 /fsm-tracking-baseline.zip
 /mtb-change-detection.zip
 /pyro-detector-baseline.zip
+/bbox-tube-temporal.zip

--- a/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/bbox-tube-temporal-gru-convnext-finetune.zip.dvc
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/bbox-tube-temporal-gru-convnext-finetune.zip.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: e651122c7807c7f9fd113423e5ea8f4e
+  size: 258728626
+  hash: md5
+  path: bbox-tube-temporal-gru-convnext-finetune.zip

--- a/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/bbox-tube-temporal-vit-dinov2-finetune.zip.dvc
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/bbox-tube-temporal-vit-dinov2-finetune.zip.dvc
@@ -2,4 +2,4 @@ outs:
 - md5: f6a972c7d14d0bdf1afc527e7d106a02
   size: 162764055
   hash: md5
-  path: bbox-tube-temporal.zip
+  path: bbox-tube-temporal-vit-dinov2-finetune.zip

--- a/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/bbox-tube-temporal.zip.dvc
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/01_raw/models/bbox-tube-temporal.zip.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: f6a972c7d14d0bdf1afc527e7d106a02
+  size: 162764055
+  hash: md5
+  path: bbox-tube-temporal.zip

--- a/experiments/temporal-models/temporal-model-leaderboard/data/07_model_output/.gitignore
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/07_model_output/.gitignore
@@ -1,4 +1,5 @@
 /fsm-tracking-baseline
 /mtb-change-detection
 /pyro-detector-baseline
-/bbox-tube-temporal
+/bbox-tube-temporal-vit-dinov2-finetune
+/bbox-tube-temporal-gru-convnext-finetune

--- a/experiments/temporal-models/temporal-model-leaderboard/data/07_model_output/.gitignore
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/07_model_output/.gitignore
@@ -1,3 +1,4 @@
 /fsm-tracking-baseline
 /mtb-change-detection
 /pyro-detector-baseline
+/bbox-tube-temporal

--- a/experiments/temporal-models/temporal-model-leaderboard/data/08_reporting/leaderboard.json
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/08_reporting/leaderboard.json
@@ -28,6 +28,20 @@
     "median_ttd_seconds": 7.0
   },
   {
+    "model_name": "bbox-tube-temporal",
+    "num_sequences": 298,
+    "tp": 144,
+    "fp": 33,
+    "fn": 5,
+    "tn": 116,
+    "precision": 0.8136,
+    "recall": 0.9664,
+    "f1": 0.8834,
+    "fpr": 0.2215,
+    "mean_ttd_seconds": 503.1,
+    "median_ttd_seconds": 328.5
+  },
+  {
     "model_name": "mtb-change-detection",
     "num_sequences": 298,
     "tp": 139,

--- a/experiments/temporal-models/temporal-model-leaderboard/data/08_reporting/leaderboard.json
+++ b/experiments/temporal-models/temporal-model-leaderboard/data/08_reporting/leaderboard.json
@@ -28,7 +28,21 @@
     "median_ttd_seconds": 7.0
   },
   {
-    "model_name": "bbox-tube-temporal",
+    "model_name": "bbox-tube-temporal-gru-convnext-finetune",
+    "num_sequences": 298,
+    "tp": 140,
+    "fp": 21,
+    "fn": 9,
+    "tn": 128,
+    "precision": 0.8696,
+    "recall": 0.9396,
+    "f1": 0.9032,
+    "fpr": 0.1409,
+    "mean_ttd_seconds": 537.4,
+    "median_ttd_seconds": 352.0
+  },
+  {
+    "model_name": "bbox-tube-temporal-vit-dinov2-finetune",
     "num_sequences": 298,
     "tp": 144,
     "fp": 33,

--- a/experiments/temporal-models/temporal-model-leaderboard/dvc.lock
+++ b/experiments/temporal-models/temporal-model-leaderboard/dvc.lock
@@ -22,8 +22,8 @@ stages:
       size: 4083
     - path: src/temporal_model_leaderboard
       hash: md5
-      md5: 423d337f89bfe4e71fb126ec3c665aae.dir
-      size: 32284
+      md5: ef7bc4a51ca678e695ff664b3b3e9192.dir
+      size: 32457
       nfiles: 12
     outs:
     - path: data/07_model_output/fsm-tracking-baseline
@@ -37,9 +37,9 @@ stages:
     deps:
     - path: data/07_model_output
       hash: md5
-      md5: 5d940174f0dd7b05a806185731d0010c.dir
-      size: 186482
-      nfiles: 10
+      md5: bb2cc12480462e146dcf9cad936f3b08.dir
+      size: 233269
+      nfiles: 12
     - path: scripts/leaderboard.py
       hash: md5
       md5: 81dec9584c04f465c99ced1b8c733a08
@@ -52,12 +52,12 @@ stages:
     outs:
     - path: data/08_reporting/leaderboard.json
       hash: md5
-      md5: c1b1768244dfd217ec0498ffabe7e273
-      size: 1121
+      md5: 4e990f1343fb88b983963d95c6eda92b
+      size: 1442
     - path: data/08_reporting/leaderboard.txt
       hash: md5
-      md5: 921d30c7d35e9756e87f8b7001ffb848
-      size: 564
+      md5: 963583362fa5ee75cb7cd56f6e67abb6
+      size: 784
   evaluate_mtb_change_detection:
     cmd: uv run python scripts/evaluate.py --model-name mtb-change-detection 
       --model-type mtb-change-detection --model-package 
@@ -80,8 +80,8 @@ stages:
       size: 4083
     - path: src/temporal_model_leaderboard
       hash: md5
-      md5: 423d337f89bfe4e71fb126ec3c665aae.dir
-      size: 32284
+      md5: ef7bc4a51ca678e695ff664b3b3e9192.dir
+      size: 32457
       nfiles: 12
     outs:
     - path: data/07_model_output/mtb-change-detection
@@ -111,8 +111,8 @@ stages:
       size: 4083
     - path: src/temporal_model_leaderboard
       hash: md5
-      md5: eaa26251bb5b72995c5c338b03c4f59f.dir
-      size: 32306
+      md5: ef7bc4a51ca678e695ff664b3b3e9192.dir
+      size: 32457
       nfiles: 12
     outs:
     - path: data/07_model_output/pyro-detector-baseline
@@ -142,12 +142,76 @@ stages:
       size: 4083
     - path: src/temporal_model_leaderboard
       hash: md5
-      md5: cb2daab05f98649c07ca00ca9b37ae77.dir
-      size: 32380
+      md5: ef7bc4a51ca678e695ff664b3b3e9192.dir
+      size: 32457
       nfiles: 12
     outs:
     - path: data/07_model_output/bbox-tube-temporal
       hash: md5
       md5: a57effcfafbca3c9420f511f37dea8d6.dir
       size: 46703
+      nfiles: 2
+  evaluate_bbox_tube_vit_dinov2_finetune:
+    cmd: uv run python scripts/evaluate.py --model-name 
+      bbox-tube-temporal-vit-dinov2-finetune --model-type bbox-tube-temporal 
+      --model-package 
+      data/01_raw/models/bbox-tube-temporal-vit-dinov2-finetune.zip --test-dir 
+      data/01_raw/sequential_test/test --output-dir 
+      data/07_model_output/bbox-tube-temporal-vit-dinov2-finetune
+    deps:
+    - path: data/01_raw/models/bbox-tube-temporal-vit-dinov2-finetune.zip
+      hash: md5
+      md5: f6a972c7d14d0bdf1afc527e7d106a02
+      size: 162764055
+    - path: data/01_raw/sequential_test
+      hash: md5
+      md5: 828edb7fb8f0909f0d6115d67ffbddc9.dir
+      size: 1594484536
+      nfiles: 32640
+    - path: scripts/evaluate.py
+      hash: md5
+      md5: 0024e38167d489e943e6e80735f9fd56
+      size: 4083
+    - path: src/temporal_model_leaderboard
+      hash: md5
+      md5: ef7bc4a51ca678e695ff664b3b3e9192.dir
+      size: 32457
+      nfiles: 12
+    outs:
+    - path: data/07_model_output/bbox-tube-temporal-vit-dinov2-finetune
+      hash: md5
+      md5: f94e53492fba19e043f45e671d44d2e9.dir
+      size: 46723
+      nfiles: 2
+  evaluate_bbox_tube_gru_convnext_finetune:
+    cmd: uv run python scripts/evaluate.py --model-name 
+      bbox-tube-temporal-gru-convnext-finetune --model-type bbox-tube-temporal 
+      --model-package 
+      data/01_raw/models/bbox-tube-temporal-gru-convnext-finetune.zip --test-dir
+      data/01_raw/sequential_test/test --output-dir 
+      data/07_model_output/bbox-tube-temporal-gru-convnext-finetune
+    deps:
+    - path: data/01_raw/models/bbox-tube-temporal-gru-convnext-finetune.zip
+      hash: md5
+      md5: e651122c7807c7f9fd113423e5ea8f4e
+      size: 258728626
+    - path: data/01_raw/sequential_test
+      hash: md5
+      md5: 828edb7fb8f0909f0d6115d67ffbddc9.dir
+      size: 1594484536
+      nfiles: 32640
+    - path: scripts/evaluate.py
+      hash: md5
+      md5: 0024e38167d489e943e6e80735f9fd56
+      size: 4083
+    - path: src/temporal_model_leaderboard
+      hash: md5
+      md5: ef7bc4a51ca678e695ff664b3b3e9192.dir
+      size: 32457
+      nfiles: 12
+    outs:
+    - path: data/07_model_output/bbox-tube-temporal-gru-convnext-finetune
+      hash: md5
+      md5: 9b29b819a25513cee29fef08948f0f75.dir
+      size: 46747
       nfiles: 2

--- a/experiments/temporal-models/temporal-model-leaderboard/dvc.lock
+++ b/experiments/temporal-models/temporal-model-leaderboard/dvc.lock
@@ -18,8 +18,8 @@ stages:
       nfiles: 32640
     - path: scripts/evaluate.py
       hash: md5
-      md5: b0f7e0612d85e1691ef78aed9bd2c118
-      size: 3979
+      md5: 0024e38167d489e943e6e80735f9fd56
+      size: 4083
     - path: src/temporal_model_leaderboard
       hash: md5
       md5: 423d337f89bfe4e71fb126ec3c665aae.dir
@@ -37,27 +37,27 @@ stages:
     deps:
     - path: data/07_model_output
       hash: md5
-      md5: 8679635cba572131844bd723271f57d5.dir
-      size: 139733
-      nfiles: 8
+      md5: 5d940174f0dd7b05a806185731d0010c.dir
+      size: 186482
+      nfiles: 10
     - path: scripts/leaderboard.py
       hash: md5
       md5: 81dec9584c04f465c99ced1b8c733a08
       size: 2507
     - path: src/temporal_model_leaderboard
       hash: md5
-      md5: 423d337f89bfe4e71fb126ec3c665aae.dir
-      size: 32284
+      md5: ef7bc4a51ca678e695ff664b3b3e9192.dir
+      size: 32457
       nfiles: 12
     outs:
     - path: data/08_reporting/leaderboard.json
       hash: md5
-      md5: a0333c0f68c720abf9000938e20ad851
-      size: 842
+      md5: c1b1768244dfd217ec0498ffabe7e273
+      size: 1121
     - path: data/08_reporting/leaderboard.txt
       hash: md5
-      md5: 49c9c9ac97a732437dfee797ee73c523
-      size: 470
+      md5: 921d30c7d35e9756e87f8b7001ffb848
+      size: 564
   evaluate_mtb_change_detection:
     cmd: uv run python scripts/evaluate.py --model-name mtb-change-detection 
       --model-type mtb-change-detection --model-package 
@@ -76,8 +76,8 @@ stages:
       nfiles: 32640
     - path: scripts/evaluate.py
       hash: md5
-      md5: b0f7e0612d85e1691ef78aed9bd2c118
-      size: 3979
+      md5: 0024e38167d489e943e6e80735f9fd56
+      size: 4083
     - path: src/temporal_model_leaderboard
       hash: md5
       md5: 423d337f89bfe4e71fb126ec3c665aae.dir
@@ -107,16 +107,47 @@ stages:
       nfiles: 32640
     - path: scripts/evaluate.py
       hash: md5
-      md5: b0f7e0612d85e1691ef78aed9bd2c118
-      size: 3979
+      md5: 0024e38167d489e943e6e80735f9fd56
+      size: 4083
     - path: src/temporal_model_leaderboard
       hash: md5
-      md5: 423d337f89bfe4e71fb126ec3c665aae.dir
-      size: 32284
+      md5: eaa26251bb5b72995c5c338b03c4f59f.dir
+      size: 32306
       nfiles: 12
     outs:
     - path: data/07_model_output/pyro-detector-baseline
       hash: md5
       md5: 0ff18e7a674f5a7c8b0452f3ce20cc4a.dir
       size: 46514
+      nfiles: 2
+  evaluate_bbox_tube_temporal:
+    cmd: uv run python scripts/evaluate.py --model-name bbox-tube-temporal 
+      --model-type bbox-tube-temporal --model-package 
+      data/01_raw/models/bbox-tube-temporal.zip --test-dir 
+      data/01_raw/sequential_test/test --output-dir 
+      data/07_model_output/bbox-tube-temporal
+    deps:
+    - path: data/01_raw/models/bbox-tube-temporal.zip
+      hash: md5
+      md5: f6a972c7d14d0bdf1afc527e7d106a02
+      size: 162764055
+    - path: data/01_raw/sequential_test
+      hash: md5
+      md5: 828edb7fb8f0909f0d6115d67ffbddc9.dir
+      size: 1594484536
+      nfiles: 32640
+    - path: scripts/evaluate.py
+      hash: md5
+      md5: 0024e38167d489e943e6e80735f9fd56
+      size: 4083
+    - path: src/temporal_model_leaderboard
+      hash: md5
+      md5: cb2daab05f98649c07ca00ca9b37ae77.dir
+      size: 32380
+      nfiles: 12
+    outs:
+    - path: data/07_model_output/bbox-tube-temporal
+      hash: md5
+      md5: a57effcfafbca3c9420f511f37dea8d6.dir
+      size: 46703
       nfiles: 2

--- a/experiments/temporal-models/temporal-model-leaderboard/dvc.yaml
+++ b/experiments/temporal-models/temporal-model-leaderboard/dvc.yaml
@@ -47,21 +47,37 @@ stages:
     outs:
       - data/07_model_output/pyro-detector-baseline
 
-  evaluate_bbox_tube_temporal:
+  evaluate_bbox_tube_vit_dinov2_finetune:
     cmd: >-
       uv run python scripts/evaluate.py
-      --model-name bbox-tube-temporal
+      --model-name bbox-tube-temporal-vit-dinov2-finetune
       --model-type bbox-tube-temporal
-      --model-package data/01_raw/models/bbox-tube-temporal.zip
+      --model-package data/01_raw/models/bbox-tube-temporal-vit-dinov2-finetune.zip
       --test-dir data/01_raw/sequential_test/test
-      --output-dir data/07_model_output/bbox-tube-temporal
+      --output-dir data/07_model_output/bbox-tube-temporal-vit-dinov2-finetune
     deps:
       - scripts/evaluate.py
       - src/temporal_model_leaderboard
       - data/01_raw/sequential_test
-      - data/01_raw/models/bbox-tube-temporal.zip
+      - data/01_raw/models/bbox-tube-temporal-vit-dinov2-finetune.zip
     outs:
-      - data/07_model_output/bbox-tube-temporal
+      - data/07_model_output/bbox-tube-temporal-vit-dinov2-finetune
+
+  evaluate_bbox_tube_gru_convnext_finetune:
+    cmd: >-
+      uv run python scripts/evaluate.py
+      --model-name bbox-tube-temporal-gru-convnext-finetune
+      --model-type bbox-tube-temporal
+      --model-package data/01_raw/models/bbox-tube-temporal-gru-convnext-finetune.zip
+      --test-dir data/01_raw/sequential_test/test
+      --output-dir data/07_model_output/bbox-tube-temporal-gru-convnext-finetune
+    deps:
+      - scripts/evaluate.py
+      - src/temporal_model_leaderboard
+      - data/01_raw/sequential_test
+      - data/01_raw/models/bbox-tube-temporal-gru-convnext-finetune.zip
+    outs:
+      - data/07_model_output/bbox-tube-temporal-gru-convnext-finetune
 
   leaderboard:
     cmd: >-

--- a/experiments/temporal-models/temporal-model-leaderboard/dvc.yaml
+++ b/experiments/temporal-models/temporal-model-leaderboard/dvc.yaml
@@ -47,6 +47,22 @@ stages:
     outs:
       - data/07_model_output/pyro-detector-baseline
 
+  evaluate_bbox_tube_temporal:
+    cmd: >-
+      uv run python scripts/evaluate.py
+      --model-name bbox-tube-temporal
+      --model-type bbox-tube-temporal
+      --model-package data/01_raw/models/bbox-tube-temporal.zip
+      --test-dir data/01_raw/sequential_test/test
+      --output-dir data/07_model_output/bbox-tube-temporal
+    deps:
+      - scripts/evaluate.py
+      - src/temporal_model_leaderboard
+      - data/01_raw/sequential_test
+      - data/01_raw/models/bbox-tube-temporal.zip
+    outs:
+      - data/07_model_output/bbox-tube-temporal
+
   leaderboard:
     cmd: >-
       uv run python scripts/leaderboard.py

--- a/experiments/temporal-models/temporal-model-leaderboard/pyproject.toml
+++ b/experiments/temporal-models/temporal-model-leaderboard/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "tracking-fsm-baseline",
     "mtb-change-detection",
     "pyro-detector-baseline",
+    "bbox-tube-temporal",
+    "tqdm>=4.67.3",
 ]
 
 [tool.uv.sources]
@@ -15,6 +17,7 @@ pyrocore = { path = "../../../lib/pyrocore" }
 tracking-fsm-baseline = { path = "../tracking-fsm-baseline" }
 mtb-change-detection = { path = "../mtb-change-detection" }
 pyro-detector-baseline = { path = "../pyro-detector-baseline" }
+bbox-tube-temporal = { path = "../bbox-tube-temporal" }
 
 [dependency-groups]
 dev = [

--- a/experiments/temporal-models/temporal-model-leaderboard/scripts/evaluate.py
+++ b/experiments/temporal-models/temporal-model-leaderboard/scripts/evaluate.py
@@ -37,6 +37,10 @@ MODEL_REGISTRY: dict[str, tuple[str, str]] = {
         "pyro_detector_baseline.model",
         "PyroDetectorModel",
     ),
+    "bbox-tube-temporal": (
+        "bbox_tube_temporal.model",
+        "BboxTubeTemporalModel",
+    ),
 }
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")

--- a/experiments/temporal-models/temporal-model-leaderboard/src/temporal_model_leaderboard/runner.py
+++ b/experiments/temporal-models/temporal-model-leaderboard/src/temporal_model_leaderboard/runner.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 from pyrocore import Frame, TemporalModel
+from tqdm import tqdm
 
 from .dataset import get_sorted_frames, list_sequences
 from .types import SequenceResult
@@ -39,7 +40,7 @@ def evaluate_model(
 
     results: list[SequenceResult] = []
 
-    for seq_path, ground_truth in sequences:
+    for seq_path, ground_truth in tqdm(sequences, desc="eval", unit="seq"):
         frame_paths = get_sorted_frames(seq_path)
         if not frame_paths:
             logger.warning("Skipping %s: no images found", seq_path.name)

--- a/experiments/temporal-models/temporal-model-leaderboard/uv.lock
+++ b/experiments/temporal-models/temporal-model-leaderboard/uv.lock
@@ -20,6 +20,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750 },
+]
+
+[[package]]
 name = "aiobotocore"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -269,6 +278,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548 },
+]
+
+[[package]]
+name = "bbox-tube-temporal"
+version = "0.1.0"
+source = { directory = "../bbox-tube-temporal" }
+dependencies = [
+    { name = "lightning" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pyrocore" },
+    { name = "pyyaml" },
+    { name = "scikit-learn" },
+    { name = "tensorboard" },
+    { name = "timm" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "ultralytics" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "lightning", specifier = ">=2.2" },
+    { name = "matplotlib", specifier = ">=3.8" },
+    { name = "numpy", specifier = ">=1.26,<2" },
+    { name = "opencv-python-headless", specifier = ">=4.8" },
+    { name = "pandas", specifier = ">=2.0" },
+    { name = "pyrocore", directory = "../../../lib/pyrocore" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "scikit-learn", specifier = ">=1.4" },
+    { name = "tensorboard", specifier = ">=2.16" },
+    { name = "timm", specifier = ">=1.0" },
+    { name = "torch", specifier = ">=2.2" },
+    { name = "torchvision", specifier = ">=0.17" },
+    { name = "tqdm", specifier = ">=4.66" },
+    { name = "ultralytics", specifier = ">=8.3" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "dvc", extras = ["s3"], specifier = ">=3.56" },
+    { name = "jupyterlab", specifier = ">=4.0" },
+    { name = "nbqa", specifier = ">=1.9" },
+    { name = "nbstripout", specifier = ">=0.8" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.9" },
 ]
 
 [[package]]
@@ -1278,6 +1337,57 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009 },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295 },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297 },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208 },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442 },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743 },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046 },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641 },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368 },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235 },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616 },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204 },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866 },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060 },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121 },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811 },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860 },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132 },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904 },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944 },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243 },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840 },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644 },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830 },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216 },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866 },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602 },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752 },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310 },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833 },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376 },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133 },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748 },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711 },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372 },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268 },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000 },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477 },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563 },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457 },
+]
+
+[[package]]
 name = "gto"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1456,6 +1566,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071 },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1574,6 +1693,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219 },
+]
+
+[[package]]
+name = "lightning"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", extra = ["http"] },
+    { name = "lightning-utilities" },
+    { name = "packaging" },
+    { name = "pytorch-lightning" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/ad/a1c91a795521be252209d45fb080f28a4f1e7244d3b37121fcc6e3e43034/lightning-2.6.1.tar.gz", hash = "sha256:859104b98c61add6fe60d0c623abf749baf25f2950a66ebdfb4bd18aa7decba9", size = 663175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/6d/42640e15a8c34b57dc7ea922152440c0c6692214a08d5282b6e3eb46ddf4/lightning-2.6.1-py3-none-any.whl", hash = "sha256:30e1adac23004c713663928541bd72ecb1371b7abc9aff9f46b7fd2644988d30", size = 853631 },
+]
+
+[[package]]
+name = "lightning-utilities"
+version = "0.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/45/7fa8f56b17dc0f0a41ec70dd307ecd6787254483549843bef4c30ab5adce/lightning_utilities-0.15.3.tar.gz", hash = "sha256:792ae0204c79f6859721ac7f386c237a33b0ed06ba775009cb894e010a842033", size = 33553 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/f4/ead6e0e37209b07c9baa3e984ccdb0348ca370b77cea3aaea8ddbb097e00/lightning_utilities-0.15.3-py3-none-any.whl", hash = "sha256:6c55f1bee70084a1cbeaa41ada96e4b3a0fea5909e844dd335bd80f5a73c5f91", size = 31906 },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180 },
 ]
 
 [[package]]
@@ -3112,6 +3273,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pytorch-lightning"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", extra = ["http"] },
+    { name = "lightning-utilities" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "torch" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/ac/ebd5f6f58691cbd4f73836e43e1727f3814311b960c41f88e259606ca2b2/pytorch_lightning-2.6.1.tar.gz", hash = "sha256:ba08f8901cf226fcca473046ad9346f414e99117762dc869c76e650d5b3d7bdc", size = 665563 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/93/c8c361bf0a2fe50f828f32def460e8b8a14b93955d3fd302b1a9b63b19e4/pytorch_lightning-2.6.1-py3-none-any.whl", hash = "sha256:1f8118567ec829e3055f16cf1aa320883a86a47c836951bfd9dcfa34ec7ffd59", size = 857273 },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -3268,6 +3448,78 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/93/093972862fb9c2fdc24ecf8d6d2212853df1945eddf26ba2625e8eaeee66/s3fs-2026.3.0.tar.gz", hash = "sha256:ce8b30a9dc5e01c5127c96cb7377290243a689a251ef9257336ac29d72d7b0d8", size = 85986 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/52/5ccdc01f7a8a61357d15a66b5d8a6580aa8529cb33f32e6cbb71c52622c5/s3fs-2026.3.0-py3-none-any.whl", hash = "sha256:2fa40a64c03003cfa5ae0e352788d97aa78ae8f9e25ea98b28ce9d21ba10c1b8", size = 32399 },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781 },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058 },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748 },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881 },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463 },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855 },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152 },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856 },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060 },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715 },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377 },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368 },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423 },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380 },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835 },
+    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381 },
+    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632 },
+    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788 },
+    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706 },
+    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451 },
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242 },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075 },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492 },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904 },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359 },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898 },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770 },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458 },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341 },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022 },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409 },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760 },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045 },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324 },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651 },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045 },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994 },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518 },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667 },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524 },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133 },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223 },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518 },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546 },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305 },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257 },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673 },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467 },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395 },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647 },
 ]
 
 [[package]]
@@ -3480,9 +3732,11 @@ name = "temporal-model-leaderboard"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "bbox-tube-temporal" },
     { name = "mtb-change-detection" },
     { name = "pyro-detector-baseline" },
     { name = "pyrocore" },
+    { name = "tqdm" },
     { name = "tracking-fsm-baseline" },
 ]
 
@@ -3495,9 +3749,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bbox-tube-temporal", directory = "../bbox-tube-temporal" },
     { name = "mtb-change-detection", directory = "../mtb-change-detection" },
     { name = "pyro-detector-baseline", directory = "../pyro-detector-baseline" },
     { name = "pyrocore", directory = "../../../lib/pyrocore" },
+    { name = "tqdm", specifier = ">=4.67.3" },
     { name = "tracking-fsm-baseline", directory = "../tracking-fsm-baseline" },
 ]
 
@@ -3506,6 +3762,61 @@ dev = [
     { name = "dvc", extras = ["s3"], specifier = ">=3.56" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.9" },
+]
+
+[[package]]
+name = "tensorboard"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/d9/a5db55f88f258ac669a92858b70a714bbbd5acd993820b41ec4a96a4d77f/tensorboard-2.20.0-py3-none-any.whl", hash = "sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6", size = 5525680 },
+]
+
+[[package]]
+name = "tensorboard-data-server"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356 },
+    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598 },
+    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363 },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638 },
+]
+
+[[package]]
+name = "timm"
+version = "1.0.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "torchvision" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/1e/e924b3b2326a856aaf68586f9c52a5fc81ef45715eca408393b68c597e0e/timm-1.0.26.tar.gz", hash = "sha256:f66f082f2f381cf68431c22714c8b70f723837fa2a185b155961eab90f2d5b10", size = 2419859 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/e9/bebf3d50e3fc847378988235f87c37ad3ac26d386041ab915d15e92025cd/timm-1.0.26-py3-none-any.whl", hash = "sha256:985c330de5ccc3a2aa0224eb7272e6a336084702390bb7e3801f3c91603d3683", size = 2568766 },
 ]
 
 [[package]]
@@ -3562,6 +3873,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835 },
     { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405 },
     { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991 },
+]
+
+[[package]]
+name = "torchmetrics"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lightning-utilities" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/34/39b8b749333db56c0585d7a11fa62a283c087bb1dfc897d69fb8cedbefb1/torchmetrics-1.9.0.tar.gz", hash = "sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa", size = 581765 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl", hash = "sha256:bfdcbff3dd1d96b3374bb2496eb39f23c4b28b8a845b6a18c313688e0d2d9ca1", size = 983384 },
 ]
 
 [[package]]
@@ -3798,6 +4124,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189 },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds **two** `bbox-tube-temporal` variants to the leaderboard pipeline as separate entries, each with self-describing names on the 298-sequence pyro-dataset v2.2.0 sequential test set:
  - **Rank 3** — `bbox-tube-temporal-gru-convnext-finetune` (ConvNext-Tiny + GRU): P=0.8696, R=0.9396, F1=0.9032, FPR=0.1409, Mean TTD 537.4s
  - **Rank 4** — `bbox-tube-temporal-vit-dinov2-finetune` (DINOv2 ViT-S/14 + Transformer): P=0.8136, R=0.9664, F1=0.8834, FPR=0.2215, Mean TTD 503.1s

  The GRU ConvNext variant has tighter precision/FPR; the DINOv2 variant has the highest recall (tied with `fsm-tracking-baseline`). Both sit between `pyro-detector-baseline` (#2) and `mtb-change-detection` (#5).
- **bbox-tube-temporal packaging**: converts the `package` dvc stage to a `foreach` over `[gru_convnext_finetune, vit_dinov2_finetune]` so `dvc repro package` emits both model zips.
- **ViT packaging fix** (landed alongside the vit_dinov2 variant): `scripts/package_model.py` and `src/bbox_tube_temporal/package.py` now propagate `global_pool`, `img_size`, transformer-head hyperparams, and `finetune*` through the classifier constructor. Without this, ViT state dicts fail to load (pos_embed `[1,257,384]` vs `[1,1370,384]` mismatch and `fc_norm`/`norm` key mismatch).
- Plumbs a `device` kwarg from `BboxTubeTemporalModel` through to `run_yolo_on_frames` so the YOLO companion runs on CUDA alongside the classifier.
- Wraps the leaderboard's per-sequence eval loop with `tqdm` for live progress (the `pyro-detector-baseline` stage took ~13 min with no visible progress during this work; tqdm fixes that UX for future runs).

## Test plan

- [x] `uv run pytest tests/` in `bbox-tube-temporal` — 63 tests pass
- [x] `uv run ruff check .` + `uv run ruff format --check .` clean in both sub-projects
- [x] `uv run dvc repro package` in `bbox-tube-temporal` emits both model zips
- [x] `uv run dvc repro evaluate_bbox_tube_vit_dinov2_finetune evaluate_bbox_tube_gru_convnext_finetune leaderboard` in `temporal-model-leaderboard` completes and regenerates `data/08_reporting/leaderboard.{json,txt}` with both rows
- [x] `dvc push` for both sub-projects (leaderboard model artifacts + regenerated eval outputs)
- [ ] Reviewer to run `cd experiments/temporal-models/temporal-model-leaderboard && make install && uv run dvc pull && uv run dvc repro` and confirm the leaderboard matches the committed `README.md`