### PR TITLE
docs(temporal-models): list bbox-tube-temporal in experiments table

### DIFF
--- a/experiments/temporal-models/README.md
+++ b/experiments/temporal-models/README.md
@@ -9,6 +9,7 @@ Experiments exploring temporal/video-based approaches to reduce false positives 
 | [tracking-fsm-baseline](tracking-fsm-baseline/) | YOLO11s detector + IoU-based FSM tracker. Requires temporal persistence (5 consecutive frames) before raising an alarm. Rule-based, no ML training. | [FLAME (Gragnaniello et al., 2024)](https://doi.org/10.1007/s00521-024-10963-z) |
 | [mtb-change-detection](mtb-change-detection/) | YOLO detection + pixel-wise frame differencing (MTB) to reject static false positives. Detections must show real pixel-level change to be confirmed. | [SlowFastMTB (Choi et al., 2022)](https://doi.org/10.1093/jcde/qwac027) |
 | [pyro-detector-baseline](pyro-detector-baseline/) | Production pyro-engine predictor (`pyro-predictor`) wrapped as a `TemporalModel` baseline. YOLO ONNX detection + per-camera sliding-window temporal smoothing. | -- |
+| [bbox-tube-temporal](bbox-tube-temporal/) | Learned temporal smoke classifier over YOLO-linked bbox tubes. 224×224 context-expanded patches through a timm backbone + temporal head (mean-pool, GRU, or transformer) produce a sequence-level smoke/no-smoke logit. | -- |
 
 ## 🏆 Leaderboard
 


### PR DESCRIPTION
## Summary
- Add the missing `bbox-tube-temporal` row to `experiments/temporal-models/README.md` so the category table reflects all five sub-projects.

## Test plan
- [x] `experiments/temporal-models/README.md` lists every sub-directory containing a `pyproject.toml` (plus the leaderboard).