### PR TITLE
fix(data-quality/frame-level): pass review-time thresholds to export

### DIFF
--- a/experiments/data-quality/frame-level/scripts/export_review_app.py
+++ b/experiments/data-quality/frame-level/scripts/export_review_app.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--conf", type=float, default=0.05)
+    parser.add_argument("--iou", type=float, default=0.05)
+    parser.add_argument("--review-conf", type=float, default=0.35)
     args = parser.parse_args()
     repo = args.repo_root
     params = yaml.safe_load((repo / "params.yaml").read_text())
@@ -30,7 +33,14 @@ def main() -> None:
 
     for model in models:
         for split in splits:
-            manifest = export_one(repo_root=repo, model=model, split=split)
+            manifest = export_one(
+                repo_root=repo,
+                model=model,
+                split=split,
+                conf=args.conf,
+                iou=args.iou,
+                review_conf=args.review_conf,
+            )
             if manifest is None:
                 log.info("skip: no review.json or predictions for %s/%s", model, split)
                 continue

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/export_runner.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/export_runner.py
@@ -11,8 +11,6 @@ import hashlib
 import subprocess
 from pathlib import Path
 
-import yaml
-
 from data_quality_frame_level.dataset import iter_frames
 from data_quality_frame_level.review_app.export import (
     ProvenanceInput,
@@ -74,8 +72,19 @@ def md5_of_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def export_one(*, repo_root: Path, model: str, split: str) -> dict | None:
+def export_one(
+    *,
+    repo_root: Path,
+    model: str,
+    split: str,
+    conf: float,
+    iou: float,
+    review_conf: float,
+) -> dict | None:
     """Export one (model, split) to ``data/10_export/<model>/<split>/``.
+
+    ``conf``/``iou``/``review_conf`` are the review-time thresholds the
+    reviewer was using; they're recorded in provenance, not used to filter.
 
     Returns the manifest payload, or ``None`` if there's no review.json
     or no predictions.json for the context.
@@ -89,13 +98,7 @@ def export_one(*, repo_root: Path, model: str, split: str) -> dict | None:
     if not predictions_path.is_file():
         return None
     split_dir = repo_root / "data" / "01_raw" / "datasets" / split
-    params = yaml.safe_load((repo_root / "params.yaml").read_text())
-    model_params = params["models"][model]
-    thresholds = {
-        "conf": float(model_params["conf_thresh"]),
-        "iou": float(model_params["iou_thresh"]),
-        "review_conf": float(model_params["review_conf_thresh"]),
-    }
+    thresholds = {"conf": conf, "iou": iou, "review_conf": review_conf}
     audit_repo, audit_commit, audit_branch = audit_git_state(repo_root)
     state = read_review_state(review_path, model=model, split=split)
     originals = {f.stem: f.gt_bboxes for f in iter_frames(split_dir)}

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/main.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/main.py
@@ -5,6 +5,7 @@ Routes:
   GET  /api/queue?model&split&view&conf&iou&review_conf  — ordered queue
   GET  /api/sample?model&split&stem&conf&iou&review_conf — layers + neighbors
   POST /api/sample?model&split  (body: SaveBody)     — save corrected GT
+  POST /api/export?model&split&conf&iou&review_conf  — write data/10_export
   GET  /image?model&split&stem                       — JPEG bytes
   GET  /                                             — static index.html
 """
@@ -183,10 +184,23 @@ def create_app(
         return {"saved_at": sample.reviewed_at}
 
     @app.post("/api/export")
-    def post_export(model: str, split: str) -> dict:
+    def post_export(
+        model: str,
+        split: str,
+        conf: float,
+        iou: float,
+        review_conf: float,
+    ) -> dict:
         if (model, split) not in contexts:
             raise HTTPException(404, f"unknown context: ({model}, {split})")
-        manifest = export_one(repo_root=repo_root, model=model, split=split)
+        manifest = export_one(
+            repo_root=repo_root,
+            model=model,
+            split=split,
+            conf=conf,
+            iou=iou,
+            review_conf=review_conf,
+        )
         if manifest is None:
             raise HTTPException(
                 400,

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
@@ -163,7 +163,7 @@ async function doExport() {
   btn.textContent = '📦 Exporting…';
   try {
     const r = await fetch(
-      `/api/export?model=${encodeURIComponent(state.model)}&split=${encodeURIComponent(state.split)}`,
+      `/api/export?model=${encodeURIComponent(state.model)}&split=${encodeURIComponent(state.split)}&conf=${state.conf}&iou=${state.iou}&review_conf=${state.reviewConf}`,
       { method: 'POST' }
     );
     if (!r.ok) {

--- a/experiments/data-quality/frame-level/tests/test_review_app_main.py
+++ b/experiments/data-quality/frame-level/tests/test_review_app_main.py
@@ -161,3 +161,67 @@ def test_get_contexts_includes_dvc_warnings(app_tree):
     assert w["model"] == "m"
     assert w["split"] == "val"
     assert w["kind"] == "stale_local"
+
+
+def test_post_export_writes_manifest(tmp_path):
+    data = tmp_path / "data"
+    split = data / "01_raw" / "datasets" / "val"
+    (split / "images").mkdir(parents=True)
+    (split / "labels").mkdir(parents=True)
+    stem = "s_2024-01-01T00-00-00"
+    (split / "images" / f"{stem}.jpg").write_bytes(b"jpeg")
+    (split / "labels" / f"{stem}.txt").write_text("0 0.5 0.5 0.1 0.1\n")
+    pred_path = data / "07_model_output" / "m" / "val" / "predictions.json"
+    pred_path.parent.mkdir(parents=True)
+    pred_path.write_text(
+        json.dumps(
+            {
+                "model_name": "m",
+                "split_dir": "data/01_raw/datasets/val",
+                "conf_thresh": 0.05,
+                "frames": {
+                    stem: {
+                        "image_path": f"images/{stem}.jpg",
+                        "predictions": [],
+                    },
+                },
+            }
+        )
+    )
+    paths = Paths(
+        split_dir=split,
+        predictions_path=pred_path,
+        review_path=data / "09_review" / "m" / "val" / "review.json",
+    )
+    app = create_app(
+        contexts={("m", "val"): paths},
+        models=["m"],
+        splits=["val"],
+        repo_root=tmp_path,
+    )
+    client = TestClient(app)
+    client.post(
+        "/api/sample",
+        params={"model": "m", "split": "val"},
+        json={
+            "stem": stem,
+            "status": "reviewed",
+            "bboxes": [{"class_id": 0, "cx": 0.4, "cy": 0.4, "w": 0.2, "h": 0.2}],
+            "reviewer": "arthur",
+        },
+    )
+    r = client.post(
+        "/api/export",
+        params={
+            "model": "m",
+            "split": "val",
+            "conf": 0.05,
+            "iou": 0.05,
+            "review_conf": 0.35,
+        },
+    )
+    assert r.status_code == 200, r.text
+    out = data / "10_export" / "m" / "val"
+    assert (out / "manifest.json").is_file()
+    prov = json.loads((out / "provenance.json").read_text())
+    assert prov["thresholds"] == {"conf": 0.05, "iou": 0.05, "review_conf": 0.35}


### PR DESCRIPTION
## Summary

- `/api/export` was 500'ing with `KeyError: 'iou_thresh'` because the FiftyOne-removal commit dropped `iou_thresh`/`review_conf_thresh` from `params.yaml` while `export_runner.export_one` still tried to read them.
- These values are now review-time UI sliders, not persisted config — so plumb `conf`/`iou`/`review_conf` from the UI through `/api/export` to `export_one`. Provenance now reflects what the reviewer actually used.
- CLI `scripts/export_review_app.py` gets matching `--conf` / `--iou` / `--review-conf` flags with defaults that mirror the UI (`0.05`/`0.05`/`0.35`).
- Adds a regression test (`test_post_export_writes_manifest`) covering the round-trip and verifying provenance thresholds.

## Test plan

- [x] `make test` (47 passed)
- [x] `make lint`, `make format`
- [x] Restart `make review-app`, hard-refresh browser, click Export — confirm 200 + manifest written to `data/10_export/<model>/<split>/`