### PR TITLE
feat(data-quality/frame-level): per-bbox spurious + verified-only preview

### DIFF
--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/export.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/export.py
@@ -23,6 +23,7 @@ from data_quality_frame_level.review_app.matching import iou
 from data_quality_frame_level.review_app.persistence import ReviewState
 
 UNCHANGED_IOU = 0.95
+SPURIOUS_MATCH_IOU = 0.95
 
 
 @dataclass(frozen=True)
@@ -108,7 +109,7 @@ def write_manifest_and_labels(
                 o
                 for o in original
                 if not any(
-                    iou(o, s) >= UNCHANGED_IOU for s in sample.spurious_originals
+                    iou(o, s) >= SPURIOUS_MATCH_IOU for s in sample.spurious_originals
                 )
             ]
         diff = compute_diff(original=original, corrected=effective)

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/export.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/export.py
@@ -101,10 +101,20 @@ def write_manifest_and_labels(
         if sample.status != "reviewed":
             continue
         original = originals.get(stem, [])
-        diff = compute_diff(original=original, corrected=sample.bboxes)
+        if sample.bboxes:
+            effective = sample.bboxes
+        else:
+            effective = [
+                o
+                for o in original
+                if not any(
+                    iou(o, s) >= UNCHANGED_IOU for s in sample.spurious_originals
+                )
+            ]
+        diff = compute_diff(original=original, corrected=effective)
         if not diff.is_change:
             continue
-        _write_yolo_txt(labels_dir / f"{stem}.txt", sample.bboxes)
+        _write_yolo_txt(labels_dir / f"{stem}.txt", effective)
         changed.append(
             {
                 "stem": stem,

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/main.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/main.py
@@ -4,7 +4,7 @@ Routes:
   GET  /api/contexts                                 — available models + splits
   GET  /api/queue?model&split&view&conf&iou&review_conf  — ordered queue
   GET  /api/sample?model&split&stem&conf&iou&review_conf — layers + neighbors
-  POST /api/sample?model&split  (body: SaveBody)     — save corrected GT
+  POST /api/sample?model&split  (body: SaveBody)     — save verified GT
   POST /api/export?model&split&conf&iou&review_conf  — write data/10_export
   GET  /image?model&split&stem                       — JPEG bytes
   GET  /                                             — static index.html
@@ -39,6 +39,7 @@ class SaveBody(BaseModel):
     stem: str
     status: str = Field(..., pattern="^(reviewed|unclear)$")
     bboxes: list[BBoxModel]
+    spurious_originals: list[BBoxModel] = Field(default_factory=list)
     reviewer: str | None = None
     note: str | None = None
 
@@ -159,7 +160,10 @@ def create_app(
                 {**asdict(p), "status": st}
                 for p, st in zip(preds, ev.pred_status, strict=True)
             ],
-            "corrected_gt": [asdict(b) for b in (sample.bboxes if sample else [])],
+            "verified_gt": [asdict(b) for b in (sample.bboxes if sample else [])],
+            "spurious_originals": [
+                asdict(b) for b in (sample.spurious_originals if sample else [])
+            ],
             "status": sample.status if sample else None,
             "reviewer": sample.reviewer if sample else None,
             "note": sample.note if sample else None,
@@ -174,10 +178,15 @@ def create_app(
             BBox(class_id=b.class_id, cx=b.cx, cy=b.cy, w=b.w, h=b.h)
             for b in body.bboxes
         ]
+        spurious = [
+            BBox(class_id=b.class_id, cx=b.cx, cy=b.cy, w=b.w, h=b.h)
+            for b in body.spurious_originals
+        ]
         sample = s.save_sample(
             stem=body.stem,
             status=body.status,
             bboxes=bboxes,
+            spurious_originals=spurious,
             reviewer=body.reviewer,
             note=body.note,
         )

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/persistence.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/persistence.py
@@ -23,6 +23,7 @@ ALLOWED_STATUS = ("reviewed", "unclear")
 class SampleReview:
     status: str
     bboxes: list[BBox] = field(default_factory=list)
+    spurious_originals: list[BBox] = field(default_factory=list)
     reviewer: str | None = None
     note: str | None = None
     reviewed_at: str | None = None
@@ -54,6 +55,8 @@ def _sample_to_dict(s: SampleReview) -> dict:
         "status": s.status,
         "bboxes": [_bbox_to_dict(b) for b in s.bboxes],
     }
+    if s.spurious_originals:
+        out["spurious_originals"] = [_bbox_to_dict(b) for b in s.spurious_originals]
     if s.reviewer is not None:
         out["reviewer"] = s.reviewer
     if s.note is not None:
@@ -69,6 +72,7 @@ def _dict_to_sample(d: dict) -> SampleReview:
     return SampleReview(
         status=d["status"],
         bboxes=[_dict_to_bbox(b) for b in d.get("bboxes", [])],
+        spurious_originals=[_dict_to_bbox(b) for b in d.get("spurious_originals", [])],
         reviewer=d.get("reviewer"),
         note=d.get("note"),
         reviewed_at=d.get("reviewed_at"),

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/state.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/state.py
@@ -80,12 +80,14 @@ class AppState:
         stem: str,
         status: str,
         bboxes: list[BBox],
+        spurious_originals: list[BBox],
         reviewer: str | None,
         note: str | None,
     ) -> SampleReview:
         sample = SampleReview(
             status=status,
             bboxes=list(bboxes),
+            spurious_originals=list(spurious_originals),
             reviewer=reviewer,
             note=note,
             reviewed_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
@@ -2,7 +2,7 @@ const state = {
   model: null, split: null,
   view: 'fp',
   conf: 0.05, iou: 0.05, reviewConf: 0.35,
-  showOrig: true, showPred: true,
+  showOrig: true, showPred: true, showOnlyVerified: false,
   reviewer: localStorage.getItem('reviewer') || '',
   queue: [], queueIndex: -1,
   sample: null,
@@ -143,6 +143,9 @@ async function init() {
   });
   document.getElementById('show-pred').addEventListener('change', e => {
     state.showPred = e.target.checked; paint();
+  });
+  document.getElementById('show-only-verified').addEventListener('change', e => {
+    state.showOnlyVerified = e.target.checked; paint();
   });
   const helpPane = document.getElementById('help-pane');
   const toggleHelp = () => { helpPane.hidden = !helpPane.hidden; };
@@ -308,9 +311,19 @@ async function loadSample(stem, opts = {}) {
 
 function setSaveBar() {
   const b = document.getElementById('save-bar');
-  if (state.dirty) { b.textContent = 'unsaved…'; b.classList.add('dirty'); }
-  else if (state.sample?.reviewed_at) { b.textContent = `✓ saved at ${state.sample.reviewed_at}`; b.classList.remove('dirty'); }
-  else { b.textContent = '— no edits —'; b.classList.remove('dirty'); }
+  if (state.dirty && !state.sample?.status) {
+    b.textContent = 'unsaved · pick a status (r / u / Space) to save';
+    b.classList.add('dirty');
+  } else if (state.dirty) {
+    b.textContent = 'unsaved…';
+    b.classList.add('dirty');
+  } else if (state.sample?.reviewed_at) {
+    b.textContent = `✓ saved at ${state.sample.reviewed_at}`;
+    b.classList.remove('dirty');
+  } else {
+    b.textContent = '— no edits —';
+    b.classList.remove('dirty');
+  }
 }
 
 function bboxToRect(b, W, H) {
@@ -329,6 +342,13 @@ function clampBbox(b) {
 function bboxClose(a, b) {
   return Math.abs(a.cx - b.cx) < 1e-6 && Math.abs(a.cy - b.cy) < 1e-6
       && Math.abs(a.w - b.w) < 1e-6 && Math.abs(a.h - b.h) < 1e-6;
+}
+function bboxIou(a, b) {
+  const ix = Math.max(0, Math.min(a.cx + a.w/2, b.cx + b.w/2) - Math.max(a.cx - a.w/2, b.cx - b.w/2));
+  const iy = Math.max(0, Math.min(a.cy + a.h/2, b.cy + b.h/2) - Math.max(a.cy - a.h/2, b.cy - b.h/2));
+  const inter = ix * iy;
+  const union = a.w * a.h + b.w * b.h - inter;
+  return union > 0 ? inter / union : 0;
 }
 
 function renderCanvas(opts = {}) {
@@ -390,29 +410,40 @@ function paint() {
   ctx2d.translate(panX, panY);
   ctx2d.scale(zoom, zoom);
   ctx2d.drawImage(img, 0, 0);
-  const corrected = state.sample.corrected_gt;
+  const verified = state.sample.verified_gt;
+  const isReviewed = state.sample.status === 'reviewed';
+  const previewMode = state.showOnlyVerified;
+  const showOrigsAsKept = isReviewed && verified.length === 0;
   const dimming = hovered !== null;
   const setAlpha = isHov => { ctx2d.globalAlpha = (dimming && !isHov) ? 0.25 : 1.0; };
   if (state.showOrig) {
+    const spurious = state.sample.spurious_originals || [];
     state.sample.original_gt.forEach((b, i) => {
-      const overridden = corrected.some(c => bboxClose(c, b));
+      const overridden = verified.some(c => bboxClose(c, b));
       if (overridden) return;
+      const isSp = spurious.some(s => bboxClose(s, b));
+      if (previewMode && (isSp || verified.length > 0 || !isReviewed)) return;
       const isHov = hovered?.layer === 'orig' && hovered.idx === i;
       setAlpha(isHov);
-      drawBox(b, { stroke: '#58a6ff', fill: 'rgba(88,166,255,.10)', fillHover: 'rgba(88,166,255,.25)', dashed: false, label: `GT (orig) · ${b.status}`, selected: selected?.layer === 'orig' && selected.idx === i, highlighted: isHov });
+      const style = isSp
+        ? { stroke: '#d97706', fill: 'rgba(217,119,6,.08)', fillHover: 'rgba(217,119,6,.20)', dashed: true, label: `GT (orig) · spurious` }
+        : showOrigsAsKept
+          ? { stroke: '#3fb950', fill: 'rgba(63,185,80,.10)', fillHover: 'rgba(63,185,80,.25)', dashed: false, label: 'GT (verified)' }
+          : { stroke: '#58a6ff', fill: 'rgba(88,166,255,.10)', fillHover: 'rgba(88,166,255,.25)', dashed: false, label: `GT (orig) · ${b.status}` };
+      drawBox(b, { ...style, selected: selected?.layer === 'orig' && selected.idx === i, highlighted: isHov });
     });
   }
-  if (state.showPred) {
+  if (state.showPred && !previewMode) {
     state.sample.predictions.forEach((p, i) => {
       const isHov = hovered?.layer === 'pred' && hovered.idx === i;
       setAlpha(isHov);
       drawBox(p, { stroke: '#f85149', fill: 'transparent', fillHover: 'rgba(248,81,73,.20)', dashed: true, label: `pred · ${p.status} · ${p.conf.toFixed(2)}`, highlighted: isHov });
     });
   }
-  corrected.forEach((b, i) => {
-    const isHov = hovered?.layer === 'corr' && hovered.idx === i;
+  verified.forEach((b, i) => {
+    const isHov = hovered?.layer === 'verified' && hovered.idx === i;
     setAlpha(isHov);
-    drawBox(b, { stroke: '#3fb950', fill: 'rgba(63,185,80,.10)', fillHover: 'rgba(63,185,80,.25)', dashed: false, label: 'GT (corr)', selected: selected?.layer === 'corr' && selected.idx === i, highlighted: isHov, handles: true });
+    drawBox(b, { stroke: '#3fb950', fill: 'rgba(63,185,80,.10)', fillHover: 'rgba(63,185,80,.25)', dashed: false, label: 'GT (verified)', selected: selected?.layer === 'verified' && selected.idx === i, highlighted: isHov, handles: true });
   });
   ctx2d.globalAlpha = 1.0;
   ctx2d.restore();
@@ -443,12 +474,12 @@ function drawBox(b, { stroke, fill, fillHover, dashed, label, selected: sel = fa
 }
 
 function hit(x, y) {
-  for (let i = state.sample.corrected_gt.length - 1; i >= 0; i--) {
-    const r = bboxToRect(state.sample.corrected_gt[i], imgNaturalW, imgNaturalH);
+  for (let i = state.sample.verified_gt.length - 1; i >= 0; i--) {
+    const r = bboxToRect(state.sample.verified_gt[i], imgNaturalW, imgNaturalH);
     const handle = handleAt(r, x, y);
-    if (handle) return { layer: 'corr', idx: i, handle };
+    if (handle) return { layer: 'verified', idx: i, handle };
     if (x >= r.x && x <= r.x + r.w && y >= r.y && y <= r.y + r.h)
-      return { layer: 'corr', idx: i, handle: 'move' };
+      return { layer: 'verified', idx: i, handle: 'move' };
   }
   if (state.showOrig) {
     for (let i = state.sample.original_gt.length - 1; i >= 0; i--) {
@@ -494,13 +525,13 @@ cnv.addEventListener('mousedown', e => {
   const h = hit(x, y);
   if (h?.layer === 'orig') {
     const o = state.sample.original_gt[h.idx];
-    state.sample.corrected_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
-    selected = { layer: 'corr', idx: state.sample.corrected_gt.length - 1 };
+    state.sample.verified_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+    selected = { layer: 'verified', idx: state.sample.verified_gt.length - 1 };
     markDirty(); paint(); renderRight(); return;
   }
-  if (h?.layer === 'corr') {
-    selected = { layer: 'corr', idx: h.idx };
-    drag = { kind: h.handle, start: { x, y }, ref: { ...state.sample.corrected_gt[h.idx] } };
+  if (h?.layer === 'verified') {
+    selected = { layer: 'verified', idx: h.idx };
+    drag = { kind: h.handle, start: { x, y }, ref: { ...state.sample.verified_gt[h.idx] } };
     paint(); return;
   }
   selected = null;
@@ -532,7 +563,7 @@ cnv.addEventListener('mousemove', e => {
   }
   if (drag.kind === 'move') {
     const dx = (x - drag.start.x) / W, dy = (y - drag.start.y) / H;
-    state.sample.corrected_gt[selected.idx] = clampBbox({ ...drag.ref, cx: drag.ref.cx + dx, cy: drag.ref.cy + dy });
+    state.sample.verified_gt[selected.idx] = clampBbox({ ...drag.ref, cx: drag.ref.cx + dx, cy: drag.ref.cy + dy });
     paint(); return;
   }
   const r0 = bboxToRect(drag.ref, W, H);
@@ -542,7 +573,7 @@ cnv.addEventListener('mousemove', e => {
   if (drag.kind === 'bl') { nw = r0.x + r0.w - x; nh = y - r0.y; nx = x; }
   if (drag.kind === 'br') { nw = x - r0.x; nh = y - r0.y; }
   if (nw < 4 || nh < 4) return;
-  state.sample.corrected_gt[selected.idx] = clampBbox(rectToBbox({ x: nx, y: ny, w: nw, h: nh }, W, H));
+  state.sample.verified_gt[selected.idx] = clampBbox(rectToBbox({ x: nx, y: ny, w: nw, h: nh }, W, H));
   paint();
 });
 
@@ -554,8 +585,8 @@ cnv.addEventListener('mouseup', e => {
     const W = imgNaturalW, H = imgNaturalH;
     const r = { x: Math.min(drag.start.x, x), y: Math.min(drag.start.y, y), w: Math.abs(x - drag.start.x), h: Math.abs(y - drag.start.y) };
     if (r.w >= 4 && r.h >= 4) {
-      state.sample.corrected_gt.push(clampBbox(rectToBbox(r, W, H)));
-      selected = { layer: 'corr', idx: state.sample.corrected_gt.length - 1 };
+      state.sample.verified_gt.push(clampBbox(rectToBbox(r, W, H)));
+      selected = { layer: 'verified', idx: state.sample.verified_gt.length - 1 };
       markDirty();
     }
   } else {
@@ -591,18 +622,19 @@ function scheduleSave() {
 
 async function persistSample() {
   if (!state.dirty || !state.sample) return;
+  if (!state.sample.status) { setSaveBar(); return; }
   const r = await api.save({
     model: state.model, split: state.split,
     body: {
       stem: state.sample.stem,
-      status: state.sample.status || 'reviewed',
-      bboxes: state.sample.corrected_gt.map(b => ({ class_id: 0, cx: b.cx, cy: b.cy, w: b.w, h: b.h })),
+      status: state.sample.status,
+      bboxes: state.sample.verified_gt.map(b => ({ class_id: 0, cx: b.cx, cy: b.cy, w: b.w, h: b.h })),
+      spurious_originals: (state.sample.spurious_originals || []).map(b => ({ class_id: 0, cx: b.cx, cy: b.cy, w: b.w, h: b.h })),
       reviewer: state.reviewer || null,
       note: state.sample.note || null,
     },
   });
   state.dirty = false;
-  state.sample.status = state.sample.status || 'reviewed';
   state.sample.reviewed_at = r.saved_at;
   setSaveBar();
   const qi = state.queue.find(q => q.stem === state.sample.stem);
@@ -628,20 +660,45 @@ function renderRight() {
     row.innerHTML = `<span class="src">${escapeHtml(src)}</span><span class="meta-x">${escapeHtml(meta)}</span><span class="actions">${actions}</span>`;
     return row;
   };
+  const spurious = state.sample.spurious_originals || [];
+  const verified = state.sample.verified_gt;
+  const isSpurious = b => spurious.some(s => bboxClose(s, b));
+  const isInVerified = b => verified.some(v => bboxClose(v, b));
+  const isReviewed = state.sample.status === 'reviewed';
+  const showOrigsAsKept = isReviewed && verified.length === 0;
+  const droppedOrigs = verified.length > 0
+    ? state.sample.original_gt.filter(b => !isSpurious(b) && !isInVerified(b))
+    : [];
+  if (droppedOrigs.length > 0) {
+    const banner = document.createElement('div');
+    banner.id = 'drop-warn';
+    banner.className = 'mb-2 rounded-md border border-amber-300 bg-amber-50 px-2 py-1.5 text-[11px] text-amber-900';
+    banner.innerHTML = `⚠️ <strong>${droppedOrigs.length}</strong> original bbox(es) will be dropped on save. <span class="actions ml-1"><button data-act="keep-all">Keep all</button> <button data-act="spurious-all">Mark all spurious</button></span>`;
+    root.appendChild(banner);
+  }
   state.sample.original_gt.forEach((b, i) => {
-    const row = make('orig', i, `GT #${i}`, b.status, `<button data-act="promote-orig" data-i="${i}">Use as GT</button>`);
+    if (isInVerified(b)) return;
+    const sp = isSpurious(b);
+    const cls = sp ? 'orig spurious' : (showOrigsAsKept ? 'orig kept' : 'orig');
+    const meta = sp
+      ? `${b.status} · spurious`
+      : (showOrigsAsKept ? `${b.status} · kept` : b.status);
+    const actions = sp
+      ? `<button data-act="restore-orig" data-i="${i}">↺ Restore</button>`
+      : `<button data-act="promote-orig" data-i="${i}">Use as GT</button> <button data-act="spurious-orig" data-i="${i}">🚫 Spurious</button>`;
+    const row = make(cls, i, `GT #${i}`, meta, actions);
     root.appendChild(row);
   });
   state.sample.predictions.forEach((p, i) => {
     const row = make('pred', i, 'pred', `${p.status} · ${p.conf.toFixed(2)}`, `<button data-act="promote-pred" data-i="${i}">Use as GT</button>`);
     root.appendChild(row);
   });
-  state.sample.corrected_gt.forEach((b, i) => {
-    const row = make('corr', i, `corr #${i}`, '', `<button data-act="del-corr" data-i="${i}">✕</button>`);
+  state.sample.verified_gt.forEach((b, i) => {
+    const row = make('verified', i, `verified #${i}`, '', `<button data-act="del-verified" data-i="${i}">✕</button>`);
     root.appendChild(row);
   });
   document.querySelectorAll('#status-pane button[data-status]').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.status === (state.sample.status || 'reviewed'));
+    btn.classList.toggle('active', btn.dataset.status === state.sample.status);
     btn.onclick = () => {
       state.sample.status = btn.dataset.status;
       markDirty();
@@ -675,15 +732,50 @@ document.getElementById('bbox-list').addEventListener('click', e => {
   const btn = e.target.closest('button[data-act]');
   if (!btn) return;
   const i = +btn.dataset.i;
+  state.sample.spurious_originals = state.sample.spurious_originals || [];
   if (btn.dataset.act === 'promote-orig') {
     const o = state.sample.original_gt[i];
-    state.sample.corrected_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+    state.sample.verified_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+    if (!state.sample.spurious_originals.some(s => bboxClose(s, o))) {
+      state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+    }
+  } else if (btn.dataset.act === 'spurious-orig') {
+    const o = state.sample.original_gt[i];
+    if (!state.sample.spurious_originals.some(s => bboxClose(s, o))) {
+      state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+    }
+  } else if (btn.dataset.act === 'restore-orig') {
+    const o = state.sample.original_gt[i];
+    state.sample.spurious_originals = state.sample.spurious_originals.filter(s => !bboxClose(s, o));
   } else if (btn.dataset.act === 'promote-pred') {
     const p = state.sample.predictions[i];
-    state.sample.corrected_gt.push({ class_id: 0, cx: p.cx, cy: p.cy, w: p.w, h: p.h });
-  } else if (btn.dataset.act === 'del-corr') {
-    state.sample.corrected_gt.splice(i, 1);
-    if (selected?.layer === 'corr' && selected.idx === i) selected = null;
+    state.sample.verified_gt.push({ class_id: 0, cx: p.cx, cy: p.cy, w: p.w, h: p.h });
+    const thr = state.iou ?? 0.05;
+    state.sample.original_gt.forEach(o => {
+      if (bboxIou(o, p) >= thr && !state.sample.spurious_originals.some(s => bboxClose(s, o))) {
+        state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+      }
+    });
+  } else if (btn.dataset.act === 'del-verified') {
+    const removed = state.sample.verified_gt.splice(i, 1)[0];
+    state.sample.spurious_originals = state.sample.spurious_originals.filter(s => !bboxClose(s, removed));
+    if (selected?.layer === 'verified' && selected.idx === i) selected = null;
+  } else if (btn.dataset.act === 'keep-all') {
+    state.sample.original_gt.forEach(o => {
+      const isSp = state.sample.spurious_originals.some(s => bboxClose(s, o));
+      const inV = state.sample.verified_gt.some(v => bboxClose(v, o));
+      if (!isSp && !inV) {
+        state.sample.verified_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+      }
+    });
+  } else if (btn.dataset.act === 'spurious-all') {
+    state.sample.original_gt.forEach(o => {
+      const inV = state.sample.verified_gt.some(v => bboxClose(v, o));
+      const already = state.sample.spurious_originals.some(s => bboxClose(s, o));
+      if (!inV && !already) {
+        state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+      }
+    });
   }
   markDirty(); paint(); renderRight();
 });
@@ -743,6 +835,10 @@ window.addEventListener('keydown', async e => {
   if (e.key === 'p') {
     state.showPred = !state.showPred;
     document.getElementById('show-pred').checked = state.showPred; paint();
+  }
+  if (e.key === 'v') {
+    state.showOnlyVerified = !state.showOnlyVerified;
+    document.getElementById('show-only-verified').checked = state.showOnlyVerified; paint();
   }
   if (e.key === '0') { resetView(); paint(); }
 });
@@ -813,8 +909,8 @@ async function jumpSequence(d) {
 
 function deleteSelected() {
   if (!state.sample || !selected) return;
-  if (selected.layer === 'corr') {
-    state.sample.corrected_gt.splice(selected.idx, 1);
+  if (selected.layer === 'verified') {
+    state.sample.verified_gt.splice(selected.idx, 1);
     selected = null;
     markDirty(); paint(); renderRight();
   }

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
@@ -333,6 +333,9 @@ function bboxClose(a, b) {
   return Math.abs(a.cx - b.cx) < 1e-6 && Math.abs(a.cy - b.cy) < 1e-6
       && Math.abs(a.w - b.w) < 1e-6 && Math.abs(a.h - b.h) < 1e-6;
 }
+function bboxCopy(b) { return { class_id: 0, cx: b.cx, cy: b.cy, w: b.w, h: b.h }; }
+function containsBbox(arr, b) { return arr.some(x => bboxClose(x, b)); }
+function withoutBbox(arr, b) { return arr.filter(x => !bboxClose(x, b)); }
 function bboxIou(a, b) {
   const ix = Math.max(0, Math.min(a.cx + a.w/2, b.cx + b.w/2) - Math.max(a.cx - a.w/2, b.cx - b.w/2));
   const iy = Math.max(0, Math.min(a.cy + a.h/2, b.cy + b.h/2) - Math.max(a.cy - a.h/2, b.cy - b.h/2));
@@ -409,9 +412,9 @@ function paint() {
   if (state.showOrig) {
     const spurious = state.sample.spurious_originals || [];
     state.sample.original_gt.forEach((b, i) => {
-      const overridden = verified.some(c => bboxClose(c, b));
+      const overridden = containsBbox(verified, b);
       if (overridden) return;
-      const isSp = spurious.some(s => bboxClose(s, b));
+      const isSp = containsBbox(spurious, b);
       if (previewMode && (isSp || verified.length > 0 || !isReviewed)) return;
       const isHov = hovered?.layer === 'orig' && hovered.idx === i;
       setAlpha(isHov);
@@ -515,7 +518,7 @@ cnv.addEventListener('mousedown', e => {
   const h = hit(x, y);
   if (h?.layer === 'orig') {
     const o = state.sample.original_gt[h.idx];
-    state.sample.verified_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
+    state.sample.verified_gt.push(bboxCopy(o));
     selected = { layer: 'verified', idx: state.sample.verified_gt.length - 1 };
     markDirty(); paint(); renderRight(); return;
   }
@@ -631,8 +634,8 @@ async function persistSample() {
     body: {
       stem: state.sample.stem,
       status: state.sample.status,
-      bboxes: state.sample.verified_gt.map(b => ({ class_id: 0, cx: b.cx, cy: b.cy, w: b.w, h: b.h })),
-      spurious_originals: (state.sample.spurious_originals || []).map(b => ({ class_id: 0, cx: b.cx, cy: b.cy, w: b.w, h: b.h })),
+      bboxes: state.sample.verified_gt.map(bboxCopy),
+      spurious_originals: (state.sample.spurious_originals || []).map(bboxCopy),
       reviewer: state.reviewer || null,
       note: state.sample.note || null,
     },
@@ -665,8 +668,8 @@ function renderRight() {
   };
   const spurious = state.sample.spurious_originals || [];
   const verified = state.sample.verified_gt;
-  const isSpurious = b => spurious.some(s => bboxClose(s, b));
-  const isInVerified = b => verified.some(v => bboxClose(v, b));
+  const isSpurious = b => containsBbox(spurious, b);
+  const isInVerified = b => containsBbox(verified, b);
   const isReviewed = state.sample.status === 'reviewed';
   const showOrigsAsKept = isReviewed && verified.length === 0;
   const droppedOrigs = verified.length > 0
@@ -736,48 +739,36 @@ document.getElementById('bbox-list').addEventListener('click', e => {
   if (!btn) return;
   const i = +btn.dataset.i;
   state.sample.spurious_originals = state.sample.spurious_originals || [];
+  const sp = state.sample.spurious_originals;
+  const verified = state.sample.verified_gt;
   if (btn.dataset.act === 'promote-orig') {
     const o = state.sample.original_gt[i];
-    state.sample.verified_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
-    if (!state.sample.spurious_originals.some(s => bboxClose(s, o))) {
-      state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
-    }
+    verified.push(bboxCopy(o));
+    if (!containsBbox(sp, o)) sp.push(bboxCopy(o));
   } else if (btn.dataset.act === 'spurious-orig') {
     const o = state.sample.original_gt[i];
-    if (!state.sample.spurious_originals.some(s => bboxClose(s, o))) {
-      state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
-    }
+    if (!containsBbox(sp, o)) sp.push(bboxCopy(o));
   } else if (btn.dataset.act === 'restore-orig') {
     const o = state.sample.original_gt[i];
-    state.sample.spurious_originals = state.sample.spurious_originals.filter(s => !bboxClose(s, o));
+    state.sample.spurious_originals = withoutBbox(sp, o);
   } else if (btn.dataset.act === 'promote-pred') {
     const p = state.sample.predictions[i];
-    state.sample.verified_gt.push({ class_id: 0, cx: p.cx, cy: p.cy, w: p.w, h: p.h });
+    verified.push(bboxCopy(p));
     const thr = state.iou ?? 0.05;
     state.sample.original_gt.forEach(o => {
-      if (bboxIou(o, p) >= thr && !state.sample.spurious_originals.some(s => bboxClose(s, o))) {
-        state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
-      }
+      if (bboxIou(o, p) >= thr && !containsBbox(sp, o)) sp.push(bboxCopy(o));
     });
   } else if (btn.dataset.act === 'del-verified') {
-    const removed = state.sample.verified_gt.splice(i, 1)[0];
-    state.sample.spurious_originals = state.sample.spurious_originals.filter(s => !bboxClose(s, removed));
+    const removed = verified.splice(i, 1)[0];
+    state.sample.spurious_originals = withoutBbox(sp, removed);
     if (selected?.layer === 'verified' && selected.idx === i) selected = null;
   } else if (btn.dataset.act === 'keep-all') {
     state.sample.original_gt.forEach(o => {
-      const isSp = state.sample.spurious_originals.some(s => bboxClose(s, o));
-      const inV = state.sample.verified_gt.some(v => bboxClose(v, o));
-      if (!isSp && !inV) {
-        state.sample.verified_gt.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
-      }
+      if (!containsBbox(sp, o) && !containsBbox(verified, o)) verified.push(bboxCopy(o));
     });
   } else if (btn.dataset.act === 'spurious-all') {
     state.sample.original_gt.forEach(o => {
-      const inV = state.sample.verified_gt.some(v => bboxClose(v, o));
-      const already = state.sample.spurious_originals.some(s => bboxClose(s, o));
-      if (!inV && !already) {
-        state.sample.spurious_originals.push({ class_id: 0, cx: o.cx, cy: o.cy, w: o.w, h: o.h });
-      }
+      if (!containsBbox(verified, o) && !containsBbox(sp, o)) sp.push(bboxCopy(o));
     });
   }
   markDirty(); paint(); renderRight();

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/app.js
@@ -311,19 +311,9 @@ async function loadSample(stem, opts = {}) {
 
 function setSaveBar() {
   const b = document.getElementById('save-bar');
-  if (state.dirty && !state.sample?.status) {
-    b.textContent = 'unsaved · pick a status (r / u / Space) to save';
-    b.classList.add('dirty');
-  } else if (state.dirty) {
-    b.textContent = 'unsaved…';
-    b.classList.add('dirty');
-  } else if (state.sample?.reviewed_at) {
-    b.textContent = `✓ saved at ${state.sample.reviewed_at}`;
-    b.classList.remove('dirty');
-  } else {
-    b.textContent = '— no edits —';
-    b.classList.remove('dirty');
-  }
+  if (state.dirty) { b.textContent = 'unsaved…'; b.classList.add('dirty'); }
+  else if (state.sample?.reviewed_at) { b.textContent = `✓ saved at ${state.sample.reviewed_at}`; b.classList.remove('dirty'); }
+  else { b.textContent = '— no edits —'; b.classList.remove('dirty'); }
 }
 
 function bboxToRect(b, W, H) {
@@ -612,7 +602,21 @@ cnv.addEventListener('wheel', e => {
   paint();
 }, { passive: false });
 
-function markDirty() { state.dirty = true; setSaveBar(); scheduleSave(); }
+function updateStatusButtons() {
+  document.querySelectorAll('#status-pane button[data-status]').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.status === state.sample?.status);
+  });
+}
+
+function markDirty() {
+  state.dirty = true;
+  if (state.sample && !state.sample.status) {
+    state.sample.status = 'reviewed';
+    updateStatusButtons();
+  }
+  setSaveBar();
+  scheduleSave();
+}
 
 let saveTimer = null;
 function scheduleSave() {
@@ -621,8 +625,7 @@ function scheduleSave() {
 }
 
 async function persistSample() {
-  if (!state.dirty || !state.sample) return;
-  if (!state.sample.status) { setSaveBar(); return; }
+  if (!state.dirty || !state.sample || !state.sample.status) return;
   const r = await api.save({
     model: state.model, split: state.split,
     body: {
@@ -698,13 +701,13 @@ function renderRight() {
     root.appendChild(row);
   });
   document.querySelectorAll('#status-pane button[data-status]').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.status === state.sample.status);
     btn.onclick = () => {
       state.sample.status = btn.dataset.status;
       markDirty();
-      document.querySelectorAll('#status-pane button[data-status]').forEach(b => b.classList.toggle('active', b === btn));
+      updateStatusButtons();
     };
   });
+  updateStatusButtons();
   const note = document.getElementById('note');
   note.value = state.sample.note || '';
   note.oninput = () => { state.sample.note = note.value || null; markDirty(); };

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/index.html
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/review_app/static/index.html
@@ -54,8 +54,11 @@
       /* Bbox rows in right panel */
       .bbox-row { @apply mb-1 flex cursor-pointer items-center gap-2 rounded-md border-l-4 px-2 py-1.5 text-xs; }
       .bbox-row.orig { @apply border-l-sky-500 bg-sky-50; }
-      .bbox-row.corr { @apply border-l-emerald-500 bg-emerald-50; }
+      .bbox-row.orig.kept { @apply border-l-emerald-500 bg-emerald-50; }
+      .bbox-row.orig.spurious { @apply border-l-amber-500 bg-amber-50 line-through text-slate-500; }
+      .bbox-row.verified { @apply border-l-emerald-500 bg-emerald-50; }
       .bbox-row.pred { @apply border-l-rose-500 bg-rose-50; }
+      #drop-warn .actions button { @apply rounded border border-amber-300 bg-white px-2 py-0.5 text-[10px] font-medium text-amber-900 transition hover:border-amber-500 hover:bg-amber-100; }
       .bbox-row .src { @apply min-w-[44px] text-[11px] font-semibold text-slate-700; }
       .bbox-row .meta-x { @apply flex-1 truncate font-mono text-[10px] text-slate-500; }
       .bbox-row .actions button { @apply rounded border border-slate-200 bg-white px-2 py-0.5 text-[10px] text-slate-600 transition hover:border-sky-300 hover:bg-sky-50 hover:text-sky-700; }
@@ -196,6 +199,7 @@
         <div id="layer-toggles" class="absolute right-3 top-3 flex gap-3 rounded-md bg-slate-900/70 px-3 py-1.5 text-xs text-slate-200 backdrop-blur-sm">
           <label class="flex items-center gap-1.5"><input type="checkbox" id="show-orig" checked class="accent-sky-400"> O · original ground truth</label>
           <label class="flex items-center gap-1.5"><input type="checkbox" id="show-pred" checked class="accent-rose-400"> P · predictions</label>
+          <label class="flex items-center gap-1.5"><input type="checkbox" id="show-only-verified" class="accent-emerald-400"> V · verified only (export preview)</label>
         </div>
       </div>
       <div id="timeline" class="flex min-h-[140px] gap-2 overflow-x-auto border-t border-slate-800 bg-slate-950 px-3 py-3 text-slate-400"></div>
@@ -225,13 +229,14 @@
           <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>r</kbd></td><td class="px-4 py-1 text-slate-600">Mark <em>reviewed</em> (stay)</td></tr>
           <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>u</kbd></td><td class="px-4 py-1 text-slate-600">Mark <em>unclear</em></td></tr>
           <tr><th colspan="2" class="bg-slate-50 px-4 pb-1 pt-2 text-left text-[9px] font-semibold uppercase tracking-wider text-slate-500">Bbox editing</th></tr>
-          <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>Del</kbd> / <kbd>Backspace</kbd></td><td class="px-4 py-1 text-slate-600">Delete selected corrected bbox</td></tr>
+          <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>Del</kbd> / <kbd>Backspace</kbd></td><td class="px-4 py-1 text-slate-600">Delete selected verified bbox</td></tr>
           <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>Esc</kbd></td><td class="px-4 py-1 text-slate-600">Clear bbox selection</td></tr>
-          <tr><td class="px-4 py-1">double-click empty</td><td class="px-4 py-1 text-slate-600">Draw a new corrected bbox</td></tr>
-          <tr><td class="px-4 py-1">click on original GT</td><td class="px-4 py-1 text-slate-600">Copy into corrected layer</td></tr>
+          <tr><td class="px-4 py-1">double-click empty</td><td class="px-4 py-1 text-slate-600">Draw a new verified bbox</td></tr>
+          <tr><td class="px-4 py-1">click on original GT</td><td class="px-4 py-1 text-slate-600">Copy into verified layer</td></tr>
           <tr><th colspan="2" class="bg-slate-50 px-4 pb-1 pt-2 text-left text-[9px] font-semibold uppercase tracking-wider text-slate-500">View</th></tr>
           <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>o</kbd></td><td class="px-4 py-1 text-slate-600">Toggle original GT layer</td></tr>
           <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>p</kbd></td><td class="px-4 py-1 text-slate-600">Toggle predictions layer</td></tr>
+          <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>v</kbd></td><td class="px-4 py-1 text-slate-600">Verified-only (export preview)</td></tr>
           <tr><td class="px-4 py-1 whitespace-nowrap"><kbd>?</kbd></td><td class="px-4 py-1 text-slate-600">Toggle this panel</td></tr>
           <tr><th colspan="2" class="bg-slate-50 px-4 pb-1 pt-2 text-left text-[9px] font-semibold uppercase tracking-wider text-slate-500">Zoom &amp; pan</th></tr>
           <tr><td class="px-4 py-1 whitespace-nowrap">wheel</td><td class="px-4 py-1 text-slate-600">Zoom in / out toward cursor</td></tr>

--- a/experiments/data-quality/frame-level/tests/test_review_app_export.py
+++ b/experiments/data-quality/frame-level/tests/test_review_app_export.py
@@ -44,9 +44,13 @@ def test_export_writes_only_changed(tmp_path: Path):
         model="m",
         split="val",
         samples={
-            "stem_a": SampleReview(status="reviewed", bboxes=[_bb(0.5, 0.5)]),
-            "stem_b": SampleReview(status="reviewed", bboxes=[_bb(0.6, 0.6)]),
-            "stem_c": SampleReview(status="unclear", bboxes=[_bb(0.5, 0.5)]),
+            "stem_a": SampleReview(status="reviewed", bboxes=[]),
+            "stem_b": SampleReview(
+                status="reviewed",
+                bboxes=[_bb(0.6, 0.6)],
+                spurious_originals=[_bb(0.5, 0.5)],
+            ),
+            "stem_c": SampleReview(status="unclear", bboxes=[]),
         },
     )
     out = tmp_path / "10_export" / "m" / "val"
@@ -59,6 +63,48 @@ def test_export_writes_only_changed(tmp_path: Path):
     manifest = json.loads((out / "manifest.json").read_text())
     assert manifest["totals"]["changed"] == 1
     assert [c["stem"] for c in manifest["changed"]] == ["stem_b"]
+
+
+def test_export_spurious_only_writes_empty_labels(tmp_path: Path):
+    originals = {"stem_x": [_bb(0.5, 0.5)]}
+    review = ReviewState(
+        model="m",
+        split="val",
+        samples={
+            "stem_x": SampleReview(
+                status="reviewed", bboxes=[], spurious_originals=[_bb(0.5, 0.5)]
+            ),
+        },
+    )
+    out = tmp_path / "10_export" / "m" / "val"
+    write_manifest_and_labels(review=review, originals=originals, out_dir=out)
+    label = (out / "labels" / "stem_x.txt").read_text()
+    assert label == ""
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["totals"] == {
+        "changed": 1,
+        "added": 0,
+        "removed": 1,
+        "modified": 0,
+    }
+
+
+def test_export_bboxes_replace_originals_when_set(tmp_path: Path):
+    """bboxes is the explicit final list; non-empty bboxes drops origs."""
+    originals = {"stem_x": [_bb(0.1, 0.1), _bb(0.5, 0.5)]}
+    review = ReviewState(
+        model="m",
+        split="val",
+        samples={
+            "stem_x": SampleReview(
+                status="reviewed", bboxes=[_bb(0.9, 0.9)], spurious_originals=[]
+            ),
+        },
+    )
+    out = tmp_path / "10_export" / "m" / "val"
+    write_manifest_and_labels(review=review, originals=originals, out_dir=out)
+    lines = (out / "labels" / "stem_x.txt").read_text().strip().splitlines()
+    assert lines == ["0 0.9 0.9 0.1 0.1"]
 
 
 def test_export_manifest_contributors_is_sorted_unique_reviewers(tmp_path: Path):

--- a/experiments/data-quality/frame-level/tests/test_review_app_main.py
+++ b/experiments/data-quality/frame-level/tests/test_review_app_main.py
@@ -117,6 +117,56 @@ def test_get_sample_returns_layers_and_neighbors(app_tree):
     }
 
 
+def test_get_sample_unreviewed_has_empty_verified_and_spurious(app_tree):
+    client, _ = app_tree
+    r = client.get(
+        "/api/sample",
+        params={
+            "model": "m",
+            "split": "val",
+            "stem": "s_2024-01-01T00-00-00",
+            "conf": 0.05,
+            "iou": 0.05,
+            "review_conf": 0.5,
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["verified_gt"] == []
+    assert body["spurious_originals"] == []
+
+
+def test_post_sample_with_spurious_persists_and_round_trips(app_tree):
+    client, paths = app_tree
+    spurious_box = {"class_id": 0, "cx": 0.5, "cy": 0.5, "w": 0.1, "h": 0.1}
+    client.post(
+        "/api/sample",
+        params={"model": "m", "split": "val"},
+        json={
+            "stem": "s_2024-01-01T00-00-00",
+            "status": "reviewed",
+            "bboxes": [],
+            "spurious_originals": [spurious_box],
+            "reviewer": "arthur",
+        },
+    )
+    payload = json.loads(paths.review_path.read_text())
+    saved = payload["samples"]["s_2024-01-01T00-00-00"]
+    assert saved["spurious_originals"] == [spurious_box]
+    body = client.get(
+        "/api/sample",
+        params={
+            "model": "m",
+            "split": "val",
+            "stem": "s_2024-01-01T00-00-00",
+            "conf": 0.05,
+            "iou": 0.05,
+            "review_conf": 0.5,
+        },
+    ).json()
+    assert body["spurious_originals"] == [spurious_box]
+
+
 def test_post_sample_persists(app_tree):
     client, paths = app_tree
     r = client.post(

--- a/experiments/data-quality/frame-level/tests/test_review_app_state.py
+++ b/experiments/data-quality/frame-level/tests/test_review_app_state.py
@@ -68,6 +68,7 @@ def test_save_sample_writes_review_json(fake_tree: Paths):
         stem="seq_2024-01-01T00-00-00",
         status="reviewed",
         bboxes=[BBox(class_id=0, cx=0.4, cy=0.4, w=0.2, h=0.2)],
+        spurious_originals=[],
         reviewer="arthur",
         note="moved",
     )


### PR DESCRIPTION
## Summary

Lets reviewers reject individual original GT bboxes during review (typical for FN frames where the shipped GT is wrong) without breaking the safe default for the common case ("just confirm, no edits"). Adds a verified-only preview mode that mirrors the export.

## What changed

**Save-time semantics (model A):**
- `bboxes` is the explicit final list. Non-empty replaces origs on export; empty + spurious markers → origs minus spurious; empty + empty → no change.
- "Use as GT" on an orig auto-marks it spurious (so promote-and-edit doesn't duplicate). "Use as GT" on a prediction auto-marks any orig with IoU ≥ active threshold as spurious.
- ✕ on a verified bbox also clears any matching spurious entry, so promote→delete restores the source orig.

**UX:**
- "corr" → "verified" everywhere (right panel, CSS, label text). Reflects the new semantic that these bboxes are what the reviewer is vouching for.
- Live banner when `verified` is non-empty AND any unspurioused orig isn't covered: "⚠️ N original bbox(es) will be dropped on save" with [Keep all] / [Mark all spurious] one-click resolutions.
- New `v` shortcut + layer toggle: verified-only preview. Hides preds, hides spurious, shows exactly what will land in the export's labels file. Unreviewed frames preview as empty.
- Reviewed frames with empty verified render kept origs in green so post-review a frame visually shows one green bbox per kept smoke.

**Bug fixes:**
- Status no longer silently defaults to `reviewed` on auto-save. Edits accumulate in JS state but defer save until reviewer explicitly picks a status; save bar prompts when waiting.

## Test plan

- [x] `make test` (51 passed — added export tests for spurious-only and bboxes-replace-originals; updated state/main tests)
- [x] `make lint`, `make format`
- [ ] Single-bbox FN: open frame → 🚫 Spurious → r → save → export → verify empty `labels/<stem>.txt`, manifest `removed=1`
- [x] Multi-bbox: open frame with 2 origs → "Use as GT" on O1 only → confirm warning banner → click "Keep all" → r → save → export shows both bboxes
- [x] Press `v` on a reviewed frame → only green; on an unreviewed frame → blank
- [x] Edit existing bbox: "Use as GT" → drag → r → save → export shows modified bbox only