### PR TITLE
data-quality/frame-level: bump pyro-dataset to v4.0.0 + show version in audit-app

### DIFF
--- a/experiments/data-quality/frame-level/data/01_raw/datasets/test/images.dvc
+++ b/experiments/data-quality/frame-level/data/01_raw/datasets/test/images.dvc
@@ -1,11 +1,11 @@
-md5: 386392cb91056dc91a0acd1963fccf9b
+md5: 4422acaba2b4d1c1335b3b28939facc3
 frozen: true
 deps:
 - path: data/processed/yolo_test/images/test
   repo:
     url: https://github.com/pyronear/pyro-dataset
-    rev: v3.0.0
-    rev_lock: ca2a1b0a47163feefaeb02ba43b239eb64898362
+    rev: v4.0.0
+    rev_lock: 4e16c464edda7400b0ac738c4f45f8d8e50fa735
 outs:
 - md5: 20a4c8a3694dcd1cee36dbd1650b7d35.dir
   size: 271913880

--- a/experiments/data-quality/frame-level/data/01_raw/datasets/test/labels.dvc
+++ b/experiments/data-quality/frame-level/data/01_raw/datasets/test/labels.dvc
@@ -1,11 +1,11 @@
-md5: 209cde7430a8ab29bc8f5ece78738df5
+md5: d4920f8e9656006bfe68d9fd20c87b20
 frozen: true
 deps:
 - path: data/processed/yolo_test/labels/test
   repo:
     url: https://github.com/pyronear/pyro-dataset
-    rev: v3.0.0
-    rev_lock: ca2a1b0a47163feefaeb02ba43b239eb64898362
+    rev: v4.0.0
+    rev_lock: 4e16c464edda7400b0ac738c4f45f8d8e50fa735
 outs:
 - md5: e1968a1821593f1b8c78580c0f9fb306.dir
   size: 96354

--- a/experiments/data-quality/frame-level/data/01_raw/datasets/train/images.dvc
+++ b/experiments/data-quality/frame-level/data/01_raw/datasets/train/images.dvc
@@ -1,11 +1,11 @@
-md5: ad7b93e3b0682c650d92d66273488e36
+md5: ff38e378a16741a94689ce62930465bb
 frozen: true
 deps:
 - path: data/processed/yolo_train_val/images/train
   repo:
     url: https://github.com/pyronear/pyro-dataset
-    rev: v3.0.0
-    rev_lock: ca2a1b0a47163feefaeb02ba43b239eb64898362
+    rev: v4.0.0
+    rev_lock: 4e16c464edda7400b0ac738c4f45f8d8e50fa735
 outs:
 - md5: 9ce15885a6e9b811c83996c4ee1b24fc.dir
   size: 1750553858

--- a/experiments/data-quality/frame-level/data/01_raw/datasets/train/labels.dvc
+++ b/experiments/data-quality/frame-level/data/01_raw/datasets/train/labels.dvc
@@ -1,11 +1,11 @@
-md5: 629b0470d94a50ad7afbc03693b09822
+md5: 7e5c5af3706469a23af9a1f50776e719
 frozen: true
 deps:
 - path: data/processed/yolo_train_val/labels/train
   repo:
     url: https://github.com/pyronear/pyro-dataset
-    rev: v3.0.0
-    rev_lock: ca2a1b0a47163feefaeb02ba43b239eb64898362
+    rev: v4.0.0
+    rev_lock: 4e16c464edda7400b0ac738c4f45f8d8e50fa735
 outs:
 - md5: 0f25a265cbaa221155ab8faf794df831.dir
   size: 869735

--- a/experiments/data-quality/frame-level/data/01_raw/datasets/val/images.dvc
+++ b/experiments/data-quality/frame-level/data/01_raw/datasets/val/images.dvc
@@ -1,11 +1,11 @@
-md5: d252e974cd9a4042cb4b5b7da7522198
+md5: 6292910e52e88c9fa1a5676a91bc263a
 frozen: true
 deps:
 - path: data/processed/yolo_train_val/images/val
   repo:
     url: https://github.com/pyronear/pyro-dataset
-    rev: v3.0.0
-    rev_lock: ca2a1b0a47163feefaeb02ba43b239eb64898362
+    rev: v4.0.0
+    rev_lock: 4e16c464edda7400b0ac738c4f45f8d8e50fa735
 outs:
 - md5: df4d690da139e65e9a42465ffb14693c.dir
   size: 161303667

--- a/experiments/data-quality/frame-level/data/01_raw/datasets/val/labels.dvc
+++ b/experiments/data-quality/frame-level/data/01_raw/datasets/val/labels.dvc
@@ -1,11 +1,11 @@
-md5: a9eba5ce11abe56b7c064b9c51278022
+md5: 1e44b7c77b9f550abbc7f5a4f1e6d09e
 frozen: true
 deps:
 - path: data/processed/yolo_train_val/labels/val
   repo:
     url: https://github.com/pyronear/pyro-dataset
-    rev: v3.0.0
-    rev_lock: ca2a1b0a47163feefaeb02ba43b239eb64898362
+    rev: v4.0.0
+    rev_lock: 4e16c464edda7400b0ac738c4f45f8d8e50fa735
 outs:
 - md5: 3ea1b0a53f08b4508d010c5c95d3c850.dir
   size: 84113

--- a/experiments/data-quality/frame-level/dvc.lock
+++ b/experiments/data-quality/frame-level/dvc.lock
@@ -27,7 +27,7 @@ stages:
     deps:
     - path: data/01_raw/datasets/train
       hash: md5
-      md5: 654706cef46e66537a2110294273984d.dir
+      md5: 4ef81dac053e8bb69d0053a390f6b59a.dir
       size: 1751424303
       nfiles: 29537
     - path: data/01_raw/models/yolo11s-nimble-narwhal.pt
@@ -67,7 +67,7 @@ stages:
     deps:
     - path: data/01_raw/datasets/val
       hash: md5
-      md5: b2da618e9b0656ec90997948c84f4737.dir
+      md5: 939e0249dcfdcacaaa09ee02aae30615.dir
       size: 161388482
       nfiles: 2855
     - path: data/01_raw/models/yolo11s-nimble-narwhal.pt
@@ -107,7 +107,7 @@ stages:
     deps:
     - path: data/01_raw/datasets/test
       hash: md5
-      md5: f659a96edceb9db05cdd332359ce4b58.dir
+      md5: 3b8457851c760a78b80b90e5d8bd813f.dir
       size: 272010928
       nfiles: 5283
     - path: data/01_raw/models/yolo11s-nimble-narwhal.pt

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/dataset_version.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/dataset_version.py
@@ -1,0 +1,53 @@
+"""Parse the pyro-dataset revision from the imported ``.dvc`` files.
+
+Each ``data/01_raw/datasets/<split>/{images,labels}.dvc`` records the
+upstream ``rev`` of pyro-dataset it was imported from. We surface that
+in the audit app header so reviewers know which dataset version they
+are looking at.
+"""
+
+from pathlib import Path
+
+import yaml
+
+_DVC_FILES = ("images.dvc", "labels.dvc")
+
+
+def _read_rev(dvc_path: Path) -> str | None:
+    payload = yaml.safe_load(dvc_path.read_text())
+    for dep in payload.get("deps", []) or []:
+        repo = dep.get("repo") or {}
+        rev = repo.get("rev")
+        if rev:
+            return str(rev)
+    return None
+
+
+def read_dataset_version(datasets_root: Path) -> str | None:
+    """Return the pyro-dataset rev pinned across all split ``.dvc`` files.
+
+    Walks ``datasets_root/<split>/{images,labels}.dvc`` and reads the
+    ``deps[0].repo.rev`` field of each. Returns:
+
+    - ``None`` when ``datasets_root`` is missing or no ``.dvc`` file
+      records a rev (e.g. fresh checkout, local-only data).
+    - A single rev string (e.g. ``"v4.0.0"``) when all files agree.
+    - ``"mixed: <r1>, <r2>, ..."`` when files disagree — a signal that
+      the imports drifted and should be reconciled.
+    """
+    if not datasets_root.is_dir():
+        return None
+    revs: set[str] = set()
+    for split_dir in sorted(p for p in datasets_root.iterdir() if p.is_dir()):
+        for name in _DVC_FILES:
+            dvc_path = split_dir / name
+            if not dvc_path.is_file():
+                continue
+            rev = _read_rev(dvc_path)
+            if rev is not None:
+                revs.add(rev)
+    if not revs:
+        return None
+    if len(revs) == 1:
+        return next(iter(revs))
+    return "mixed: " + ", ".join(sorted(revs))

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/main.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/main.py
@@ -18,6 +18,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
+from data_quality_frame_level.audit_app.dataset_version import read_dataset_version
 from data_quality_frame_level.audit_app.export_runner import export_one
 from data_quality_frame_level.audit_app.matching import evaluate_frame
 from data_quality_frame_level.audit_app.persistence import dvc_warning_for_review
@@ -70,7 +71,14 @@ def create_app(
             w = dvc_warning_for_review(paths.review_path)
             if w is not None:
                 warnings.append({**w, "model": m, "split": s})
-        return {"models": models, "splits": splits, "dvc_warnings": warnings}
+        return {
+            "models": models,
+            "splits": splits,
+            "dvc_warnings": warnings,
+            "dataset_version": read_dataset_version(
+                repo_root / "data" / "01_raw" / "datasets"
+            ),
+        }
 
     @app.get("/api/queue")
     def get_queue(

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
@@ -92,6 +92,7 @@ async function init() {
 
   const ctxs = await api.contexts();
   renderDvcBanners(ctxs.dvc_warnings || []);
+  renderDatasetVersion(ctxs.dataset_version);
   const selModel = document.getElementById('sel-model');
   const selSplit = document.getElementById('sel-split');
   ctxs.models.forEach(m => selModel.add(new Option(m, m)));
@@ -261,6 +262,17 @@ function renderQueue() {
 
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, ch => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));
+}
+
+function renderDatasetVersion(rev) {
+  const el = document.getElementById('dataset-version');
+  if (!rev) { el.hidden = true; return; }
+  el.textContent = `dataset ${rev}`;
+  el.hidden = false;
+  if (rev.startsWith('mixed:')) {
+    el.classList.remove('border-slate-200', 'bg-slate-50', 'text-slate-600');
+    el.classList.add('border-amber-300', 'bg-amber-50', 'text-amber-800');
+  }
 }
 
 function renderDvcBanners(warnings) {

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
@@ -126,6 +126,7 @@
 
   <header class="flex h-12 items-center gap-3 border-b border-slate-200 bg-white px-4 shadow-sm">
     <strong class="text-sm font-semibold tracking-tight text-slate-900">🔥 Label audit</strong>
+    <span id="dataset-version" title="pyro-dataset rev imported into data/01_raw/datasets" hidden class="rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-[11px] text-slate-600"></span>
     <span class="flex-1"></span>
     <label class="flex items-center gap-1.5 text-xs text-slate-500">model
       <select id="sel-model" class="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 shadow-sm focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400"></select>

--- a/experiments/data-quality/frame-level/tests/test_audit_app_dataset_version.py
+++ b/experiments/data-quality/frame-level/tests/test_audit_app_dataset_version.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from data_quality_frame_level.audit_app.dataset_version import read_dataset_version
+
+_DVC_TEMPLATE = """\
+md5: abc
+frozen: true
+deps:
+- path: data/processed/yolo_train_val/images/{split}
+  repo:
+    url: https://github.com/pyronear/pyro-dataset
+    rev: {rev}
+    rev_lock: deadbeef
+outs:
+- md5: cafebabe.dir
+  path: {kind}
+"""
+
+
+def _write(root: Path, split: str, kind: str, rev: str) -> None:
+    d = root / split
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{kind}.dvc").write_text(
+        _DVC_TEMPLATE.format(split=split, rev=rev, kind=kind)
+    )
+
+
+def test_returns_none_when_root_missing(tmp_path: Path):
+    assert read_dataset_version(tmp_path / "nope") is None
+
+
+def test_returns_none_when_no_dvc_files(tmp_path: Path):
+    (tmp_path / "train").mkdir()
+    assert read_dataset_version(tmp_path) is None
+
+
+def test_returns_single_rev_when_all_agree(tmp_path: Path):
+    for split in ("train", "val", "test"):
+        for kind in ("images", "labels"):
+            _write(tmp_path, split, kind, "v4.0.0")
+    assert read_dataset_version(tmp_path) == "v4.0.0"
+
+
+def test_returns_mixed_when_revs_disagree(tmp_path: Path):
+    _write(tmp_path, "train", "images", "v4.0.0")
+    _write(tmp_path, "train", "labels", "v4.0.0")
+    _write(tmp_path, "val", "images", "v3.0.0")
+    _write(tmp_path, "val", "labels", "v4.0.0")
+    out = read_dataset_version(tmp_path)
+    assert out == "mixed: v3.0.0, v4.0.0"
+
+
+def test_ignores_dvc_without_repo_section(tmp_path: Path):
+    (tmp_path / "train").mkdir()
+    (tmp_path / "train" / "images.dvc").write_text(
+        "outs:\n- md5: foo.dir\n  path: images\n"
+    )
+    _write(tmp_path, "val", "images", "v4.0.0")
+    assert read_dataset_version(tmp_path) == "v4.0.0"


### PR DESCRIPTION
## Summary
- Bumps the imported pyro-dataset rev in the six `experiments/data-quality/frame-level/data/01_raw/datasets/*/*.dvc` files from `v3.0.0` to `v4.0.0` (commit `4e16c464`) and refreshes `dvc.lock` after rerunning `predict_{train,val,test}`. Frame counts are unchanged (train=14767, val=1426, test=2640) → v4.0.0 is a label-only refresh.
- Surfaces the imported dataset rev as a small badge next to the audit-app title (e.g. `dataset v4.0.0`). Parsed from the `.dvc` files at startup; turns amber and shows `mixed: v3.0.0, v4.0.0` if the imports drift across splits.

## Test plan
- [x] `make lint` clean
- [x] `make test` — 56 passed (5 new tests for `read_dataset_version`)
- [x] `uv run dvc repro` regenerated `predictions.json` for all three splits
- [x] Open the audit app and confirm the `dataset v4.0.0` badge renders in the header
- [x] Saved reviews from v3.0.0 still match v4.0.0 stems (frame counts are unchanged, so this should hold, but worth a visual check on a few previously-reviewed sequences)