### PR TITLE
review(data-quality/frame-level): first DVC-tracked review export + drop FiftyOne gitignore leftovers

### DIFF
--- a/experiments/data-quality/frame-level/data/.gitignore
+++ b/experiments/data-quality/frame-level/data/.gitignore
@@ -1,0 +1,2 @@
+/09_review
+/10_export

--- a/experiments/data-quality/frame-level/data/09_review.dvc
+++ b/experiments/data-quality/frame-level/data/09_review.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 47257496ea1d99774670625b55b54fe3.dir
+  size: 37592
+  nfiles: 10
+  hash: md5
+  path: 09_review

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test/.gitignore
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test/.gitignore
@@ -1,2 +1,0 @@
-/review.json
-/review.json.bak*

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/train/.gitignore
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/train/.gitignore
@@ -1,2 +1,0 @@
-/review.json
-/review.json.bak*

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/val/.gitignore
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/val/.gitignore
@@ -1,2 +1,0 @@
-/review.json
-/review.json.bak*

--- a/experiments/data-quality/frame-level/data/10_export.dvc
+++ b/experiments/data-quality/frame-level/data/10_export.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 383a82b4af8c92ea51dc882ca6895062.dir
+  size: 3471
+  nfiles: 12
+  hash: md5
+  path: 10_export

--- a/experiments/data-quality/frame-level/data/10_export/.gitignore
+++ b/experiments/data-quality/frame-level/data/10_export/.gitignore
@@ -1,1 +1,0 @@
-/yolo11s-nimble-narwhal


### PR DESCRIPTION
## Summary
- First DVC-tracked review export under the new bbox-editing audit workflow: 1 corrected sample on the `test` split (`pyronear-force-06_courmettes_212_2024-01-16T09-50-12`, 1 box removed), contributor `arthur`. Pushed to S3.
- Removes leftover per-split `.gitignore` files (and `data/09_review/.gitkeep`) from the dropped FiftyOne workflow — these blocked `dvc add data/09_review data/10_export` because DVC refuses to take ownership of a directory containing git-tracked files.
- New tracking moves to parent-directory DVC outputs (`data/09_review.dvc`, `data/10_export.dvc`), matching the README's review hand-off recipe.

## Test plan
- [x] `uv run dvc status -c data/09_review.dvc data/10_export.dvc` → "Cache and remote 's3remote' are in sync."
- [x] Reviewer can `git pull` + `uv run dvc pull data/09_review data/10_export` on a fresh checkout and see Arthur's corrected sample.
- [x] Next reviewer's `make audit-app` shows the existing test-split correction as a green-dot reviewed sample.