### PR TITLE
feat(data-quality/frame-level): per-split parallel annotation workflow

### DIFF
--- a/experiments/data-quality/frame-level/Makefile
+++ b/experiments/data-quality/frame-level/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format test help notebook audit-app audit-export
+.PHONY: install lint format test help notebook audit-app audit-export audit-publish
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -25,7 +25,8 @@ audit-app: ## Launch the bbox-editing audit app on http://localhost:8000
 audit-export: ## Build YOLO-format patches under data/10_export/ from review.json
 	uv run --group audit-app python scripts/export_audit_app.py
 	@echo ""
-	@echo "Next steps to share the export:"
-	@echo "  uv run dvc add data/10_export && uv run dvc push"
-	@echo "  git add data/10_export.dvc data/.gitignore && git commit -m 'export: refresh corrections'"
+	@echo "Next: make audit-publish    # detect dirty splits, push + commit per split"
+
+audit-publish: ## Push + commit review/export per dirty split (interactive). MODEL=<name> to override.
+	@bash scripts/audit_publish.sh
 

--- a/experiments/data-quality/frame-level/Makefile
+++ b/experiments/data-quality/frame-level/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format test help notebook audit-app audit-export audit-publish
+.PHONY: install lint format test help notebook audit-app audit-export audit-publish audit-summary
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -29,4 +29,12 @@ audit-export: ## Build YOLO-format patches under data/10_export/ from review.jso
 
 audit-publish: ## Push + commit review/export per dirty split (interactive). MODEL=<name> to override.
 	@bash scripts/audit_publish.sh
+
+audit-summary: ## Print per-split summary (reviewed / changed / pending / contributors). MODEL=<name> to override.
+	@MODEL="$${MODEL:-yolo11s-nimble-narwhal}"; \
+	for s in train val test; do \
+	    echo "▸ $$s"; \
+	    uv run python scripts/summarize_split.py --model "$$MODEL" --split "$$s"; \
+	    echo; \
+	done
 

--- a/experiments/data-quality/frame-level/README.md
+++ b/experiments/data-quality/frame-level/README.md
@@ -25,12 +25,16 @@ uv run dvc repro
 # Start a review session:
 make audit-app                # opens http://localhost:8000
 
-# End of session — emit the patch + push:
-make audit-export
-uv run dvc add data/09_review data/10_export && uv run dvc push
-git add data/09_review.dvc data/10_export.dvc data/.gitignore
-git commit -m "review: bbox corrections + export"
+# End of session — emit the patch, then publish your splits:
+make audit-export             # writes data/10_export/<model>/<split>/
+make audit-publish            # interactive: per-split summary, y/N, push, commit
+git push                      # share with the team
 ```
+
+`make audit-publish` detects which splits actually changed (via `dvc
+status`), shows a summary, and prompts y/N per split — different
+reviewers can work on different splits in parallel and land independent
+commits without stepping on each other.
 
 <img width="1651" height="1044" alt="image" src="https://github.com/user-attachments/assets/89317d03-a8e1-49a5-8175-300a6d9f94b5" />
 
@@ -78,11 +82,10 @@ make audit-app                # starts the app on http://localhost:8000
 
 # (Review samples in the browser — see "How to use the app" below.)
 
-# End of session — emit the patch + push:
-make audit-export
-uv run dvc add data/09_review data/10_export && uv run dvc push
-git add data/09_review.dvc data/10_export.dvc data/.gitignore
-git commit -m "review: bbox corrections + export"
+# End of session — emit the patch + publish:
+make audit-export             # writes data/10_export/<model>/<split>/
+make audit-publish            # interactive: per-split summary, y/N, push, commit
+git push                      # share with the team
 ```
 
 ### Data flow & files persisted
@@ -137,26 +140,35 @@ lives entirely in `review.json` keyed by stem.
 6. **See keyboard shortcuts and color legend** — click the `?` icon in
    the header (or press `?`) to toggle the reference panel.
 
-### Sequential hand-off across reviewers
+### Working in parallel across reviewers
 
-`review.json` is a single per-`(model, split)` file shared via DVC:
+`data/09_review/<model>/<split>/` and `data/10_export/<model>/<split>/`
+are tracked **per split** (one `.dvc` file per split), so different
+reviewers can take different splits and land independent commits
+concurrently — no DVC or git collisions on the umbrella directory.
 
 ```bash
-# Mateo, on his machine:
-make audit-app    # reviews 50 samples, auto-saved to local review.json
-uv run dvc add data/09_review && uv run dvc push
-git add data/09_review.dvc && git commit -m "review: mateo's val pass" && git push
+# Mateo takes val:
+make audit-app                        # reviews val in the browser
+make audit-export                     # writes data/10_export/<m>/val/
+make audit-publish                    # detects val dirty, prompts, pushes,
+                                      #   commits 'review(val): bbox ...'
+git push
 
-# Felix, on his machine:
-git pull
-uv run dvc pull data/09_review   # fetches Mateo's reviewed samples
-make audit-app                    # Mateo's reviews show as green dots; Felix continues
+# Felix takes train, in parallel on his machine:
+make audit-app                        # reviews train
+make audit-export
+make audit-publish                    # detects train dirty, commits 'review(train): ...'
+git push                              # merges cleanly — disjoint .dvc files
 ```
 
-Felix's saves are unioned into the same `review.json` (each sample
-carries its own `reviewer` field). The header shows a yellow banner if
-the local `review.json` md5 differs from the DVC-tracked md5 — your
-cue to `dvc pull` before reviewing to avoid overwriting work.
+**Same split, sequential hand-off.** When two reviewers work on the
+same split, `review.json` is unioned (each sample carries its own
+`reviewer` field). The second reviewer should `git pull` and `dvc pull
+data/09_review/<m>/<s>.dvc` before starting; the app's header shows a
+yellow banner if the local `review.json` md5 differs from the
+DVC-tracked md5 — your cue that someone else's work hasn't been
+fetched yet.
 
 ### Apply the export to pyro-dataset
 
@@ -254,8 +266,10 @@ data/
       <model-name>.pt                               # downloaded; not dvc-tracked
   07_model_output/<model-name>/<split>/
     predictions.json
-  09_review/<model-name>/<split>/
-    review.json                                     # bbox corrections (DVC-tracked)
-  10_export/<model-name>/<split>/
-    labels/, manifest.json, pending.json, provenance.json
+  09_review/<model-name>/
+    <split>.dvc                                     # one .dvc per split (DVC-tracked)
+    <split>/review.json                             # bbox corrections
+  10_export/<model-name>/
+    <split>.dvc                                     # one .dvc per split (DVC-tracked)
+    <split>/labels/, manifest.json, pending.json, provenance.json
 ```

--- a/experiments/data-quality/frame-level/README.md
+++ b/experiments/data-quality/frame-level/README.md
@@ -170,6 +170,12 @@ yellow banner if the local `review.json` md5 differs from the
 DVC-tracked md5 — your cue that someone else's work hasn't been
 fetched yet.
 
+**Check progress at any time.** `make audit-summary` prints the
+per-split counts (reviewed / changed / pending / contributors) from
+each split's `manifest.json` without touching DVC. Useful before
+deciding which split to pick up, or to spot splits whose `review.json`
+is newer than their last export (warning fires inline).
+
 ### Apply the export to pyro-dataset
 
 The export's `manifest.json` is the contract; `pyro-dataset` provides

--- a/experiments/data-quality/frame-level/data/.gitignore
+++ b/experiments/data-quality/frame-level/data/.gitignore
@@ -1,2 +1,0 @@
-/09_review
-/10_export

--- a/experiments/data-quality/frame-level/data/09_review.dvc
+++ b/experiments/data-quality/frame-level/data/09_review.dvc
@@ -1,6 +1,0 @@
-outs:
-- md5: 9c4c62e92eda41f9f800081c18789a0a.dir
-  size: 140116
-  nfiles: 10
-  hash: md5
-  path: 09_review

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/.gitignore
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/.gitignore
@@ -1,0 +1,3 @@
+/train
+/val
+/test

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: da061d28d367fabd054945590ca1bc9d.dir
+  size: 494
+  nfiles: 1
+  hash: md5
+  path: test

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: da061d28d367fabd054945590ca1bc9d.dir
-  size: 494
+- md5: 82e60d7a0daa9fe7f8b88251b006b0d9.dir
+  size: 862
   nfiles: 1
   hash: md5
   path: test

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/train.dvc
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/train.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: d9e85b759dc39a919baeb490a26b6e3a.dir
+  size: 10552
+  nfiles: 1
+  hash: md5
+  path: train

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/val.dvc
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/val.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 115676eee9cdfc6b7a5a0f850db451d9.dir
+  size: 102570
+  nfiles: 1
+  hash: md5
+  path: val

--- a/experiments/data-quality/frame-level/data/10_export.dvc
+++ b/experiments/data-quality/frame-level/data/10_export.dvc
@@ -1,6 +1,0 @@
-outs:
-- md5: f076ae67b7f8e5dcb381e070cb35a9be.dir
-  size: 28807
-  nfiles: 92
-  hash: md5
-  path: 10_export

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/.gitignore
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/.gitignore
@@ -1,0 +1,3 @@
+/train
+/val
+/test

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 23b448ba25af797264e5244856aae1b3.dir
+  size: 1165
+  nfiles: 4
+  hash: md5
+  path: test

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: cb588d3811208d30624ac6019d44f153.dir
-  size: 1173
+- md5: 99fe154bc9ae2a3c5bb05c50e142d641.dir
+  size: 1179
   nfiles: 4
   hash: md5
   path: test

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 23b448ba25af797264e5244856aae1b3.dir
-  size: 1165
+- md5: cb588d3811208d30624ac6019d44f153.dir
+  size: 1173
   nfiles: 4
   hash: md5
   path: test

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/train.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/train.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 2744f800785ecacf7085a9e656a20b47.dir
-  size: 5891
+- md5: 289c1628aca8e8553dc79463402f2f04.dir
+  size: 5885
   nfiles: 22
   hash: md5
   path: train

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/train.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/train.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 2744f800785ecacf7085a9e656a20b47.dir
+  size: 5891
+  nfiles: 22
+  hash: md5
+  path: train

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/val.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/val.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 130d860bf9272cbc2c56ebdd72afbad2.dir
+  size: 26290
+  nfiles: 83
+  hash: md5
+  path: val

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/val.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/val.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 130d860bf9272cbc2c56ebdd72afbad2.dir
-  size: 26290
+- md5: f171ef5881dbc03eaca86c59b21a305e.dir
+  size: 26338
   nfiles: 83
   hash: md5
   path: val

--- a/experiments/data-quality/frame-level/scripts/audit_publish.sh
+++ b/experiments/data-quality/frame-level/scripts/audit_publish.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Publish review + export artifacts to DVC and commit, per split.
+#
+# Detects which splits have changes (via dvc status), shows a summary,
+# prompts y/N per split, and for each confirmed split:
+#   1. dvc add data/09_review/<m>/<s> data/10_export/<m>/<s>
+#   2. dvc push (targeted to that split's .dvc files)
+#   3. git add the split's .dvc files (+ .gitignore on first publish)
+#   4. git commit -e -m "review(<s>): bbox corrections + export"
+#
+# Each split is atomic: data on the DVC remote + git commit, or neither.
+# git's commit editor (-e) is the message confirmation step.
+#
+# Usage:
+#   make audit-publish            # uses default model
+#   MODEL=other-model make audit-publish
+
+set -euo pipefail
+
+MODEL="${MODEL:-yolo11s-nimble-narwhal}"
+SPLITS=(train val test)
+
+if [[ -f data/09_review.dvc || -f data/10_export.dvc ]]; then
+    echo "ERROR: data/09_review and data/10_export are still tracked at the"
+    echo "umbrella level (data/09_review.dvc / data/10_export.dvc exist)."
+    echo "This branch expects per-split DVC tracking — check git log for the"
+    echo "commit that converted tracking, and rebase/merge it in."
+    exit 1
+fi
+
+if [[ ! -d data/09_review/$MODEL ]]; then
+    echo "ERROR: data/09_review/$MODEL/ not found. Wrong MODEL or no reviews yet?"
+    exit 1
+fi
+
+dirty=()
+for s in "${SPLITS[@]}"; do
+    review="data/09_review/$MODEL/$s/review.json"
+    [[ -f "$review" ]] || continue
+    if ! uv run dvc status -q \
+        "data/09_review/$MODEL/$s" "data/10_export/$MODEL/$s" >/dev/null 2>&1; then
+        dirty+=("$s")
+    fi
+done
+
+if [[ ${#dirty[@]} -eq 0 ]]; then
+    echo "Nothing to publish — all tracked splits match the DVC cache."
+    exit 0
+fi
+
+echo "Detected changes in: ${dirty[*]}"
+echo
+
+published=()
+for s in "${dirty[@]}"; do
+    echo "▸ $s"
+    uv run python scripts/summarize_split.py --model "$MODEL" --split "$s"
+    read -r -p "  Publish $s? [y/N]: " ans
+    if [[ ! "$ans" =~ ^[Yy]$ ]]; then
+        echo "  Skipped $s."
+        echo
+        continue
+    fi
+
+    uv run dvc add "data/09_review/$MODEL/$s" "data/10_export/$MODEL/$s"
+    uv run dvc push \
+        "data/09_review/$MODEL/$s.dvc" "data/10_export/$MODEL/$s.dvc"
+
+    git add \
+        "data/09_review/$MODEL/$s.dvc" \
+        "data/10_export/$MODEL/$s.dvc"
+    # .gitignore only changes on first publish after migration; ignore failure.
+    git add -- \
+        "data/09_review/$MODEL/.gitignore" \
+        "data/10_export/$MODEL/.gitignore" 2>/dev/null || true
+
+    if ! git commit -e -m "review($s): bbox corrections + export"; then
+        echo
+        echo "Commit aborted for $s. Data is on the DVC remote but uncommitted;"
+        echo "files remain staged. Resolve manually (git restore --staged ...)"
+        echo "or re-run this command."
+        exit 1
+    fi
+    published+=("$s")
+    echo
+done
+
+if [[ ${#published[@]} -eq 0 ]]; then
+    echo "Nothing was published."
+    exit 0
+fi
+
+echo "Published: ${published[*]}"
+echo "Run 'git push' to share with the team."

--- a/experiments/data-quality/frame-level/scripts/summarize_split.py
+++ b/experiments/data-quality/frame-level/scripts/summarize_split.py
@@ -1,0 +1,68 @@
+"""Print a one-block summary of an export for a (model, split).
+
+Reads ``data/10_export/<model>/<split>/{manifest.json,pending.json}`` and
+prints reviewer-facing counts (reviewed, changed, added/removed/modified,
+pending unclear, contributors). Used by ``scripts/audit_publish.sh`` to
+show what a reviewer is about to publish.
+
+Exits 0 in all non-error cases. Prints a warning line if ``manifest.json``
+is older than ``review.json`` (i.e. the app's Export button wasn't clicked
+after the latest edits).
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _fmt(label: str, value: str) -> str:
+    return f"    {label:<22}{value}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--split", required=True, choices=["train", "val", "test"])
+    args = parser.parse_args()
+
+    review = (
+        args.repo_root / "data" / "09_review" / args.model / args.split / "review.json"
+    )
+    export_dir = args.repo_root / "data" / "10_export" / args.model / args.split
+    manifest_path = export_dir / "manifest.json"
+    pending_path = export_dir / "pending.json"
+
+    if not manifest_path.is_file():
+        print("    (no manifest — click Export in the app first)")
+        return 0
+
+    manifest = json.loads(manifest_path.read_text())
+    pending = (
+        json.loads(pending_path.read_text()).get("pending", [])
+        if pending_path.is_file()
+        else []
+    )
+    t = manifest["totals"]
+    contributors = manifest.get("contributors") or []
+
+    print(_fmt("reviewed:", str(t["reviewed"])))
+    changed_detail = (
+        f"{t['changed']}   "
+        f"(+{t['added']} added, -{t['removed']} removed, ~{t['modified']} modified)"
+    )
+    print(_fmt("changed:", changed_detail))
+    print(_fmt("pending (unclear):", str(len(pending))))
+    print(_fmt("contributors:", ", ".join(contributors) if contributors else "(none)"))
+
+    if review.is_file() and review.stat().st_mtime > manifest_path.stat().st_mtime:
+        print(
+            "    !! review.json is newer than manifest.json — "
+            "click Export in the app to refresh"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Switches DVC tracking for `data/09_review/` and `data/10_export/` from one umbrella hash to per-split `.dvc` files (per `<model>/<split>`), so reviewers can publish independent splits without colliding on a single hash.
- New `make audit-publish` — interactive per-split workflow: detects dirty splits via `dvc status`, prints a summary (reviewed / changed / pending / contributors from `manifest.json`), prompts y/N per split, then atomically runs `dvc add` + targeted `dvc push` + `git commit -e` (editor opens for message confirmation; empty message aborts cleanly).
- README rewritten around per-split parallel as the canonical flow; same-split sequential hand-off documented as the exception.
- The two `review(train)` / `review(test)` commits at the tip exercise the new workflow end-to-end.

## Test plan

- [x] `make audit-publish` on a clean tree reports "Nothing to publish"
- [x] Click 📦 Export in the UI for one split, then `make audit-publish` detects only that split as dirty
- [x] Aborting the commit editor (empty message) stops the script cleanly with files staged
- [x] Two reviewers on different splits both run `make audit-publish` concurrently and land commits without merge conflicts (requires a second machine to verify; merges of disjoint `.dvc` files have no theoretical conflict path)