### PR TITLE
feat(data-quality/frame-level): add make export-viewer

### DIFF
--- a/experiments/data-quality/frame-level/Makefile
+++ b/experiments/data-quality/frame-level/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint format test help notebook audit-app audit-export audit-publish audit-summary
+.PHONY: install lint format test help notebook audit-app audit-export audit-publish audit-summary export-viewer
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -37,4 +37,7 @@ audit-summary: ## Print per-split summary (reviewed / changed / pending / contri
 	    uv run python scripts/summarize_split.py --model "$$MODEL" --split "$$s"; \
 	    echo; \
 	done
+
+export-viewer: ## Launch the read-only export viewer on http://localhost:8001
+	uv run --group audit-app python scripts/run_export_viewer.py
 

--- a/experiments/data-quality/frame-level/scripts/run_export_viewer.py
+++ b/experiments/data-quality/frame-level/scripts/run_export_viewer.py
@@ -1,0 +1,37 @@
+"""Launch the read-only export viewer.
+
+Discovers exported (model, split) pairs under ``data/10_export/`` and serves
+a browser viewer for the YOLO labels + images at
+``data/01_raw/datasets/<split>/images/``.
+
+Usage::
+
+    uv run --group audit-app python scripts/run_export_viewer.py
+"""
+
+import argparse
+from pathlib import Path
+
+import uvicorn
+
+from data_quality_frame_level.export_viewer.main import create_app, discover_contexts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8001)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    contexts = discover_contexts(args.repo_root)
+    if not contexts:
+        print(f"No exports found under {args.repo_root / 'data/10_export'}")
+    else:
+        for c in contexts:
+            print(f"  {c.model} / {c.split}  ({c.labels_dir})")
+    app = create_app(contexts=contexts)
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/export_viewer/main.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/export_viewer/main.py
@@ -1,0 +1,145 @@
+"""Read-only viewer for exported YOLO labels under ``data/10_export/``.
+
+Routes:
+  GET /api/contexts             — exported (model, split) pairs with frame counts
+  GET /api/frames?model&split   — sorted stems present in the export
+  GET /api/sample?model&split&stem — parsed YOLO bboxes for the stem
+  GET /image?split&stem         — JPEG bytes from data/01_raw/datasets/<split>/images
+  GET /                         — static index.html
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from data_quality_frame_level.audit_app.sequence import (
+    assign_temporal_sequences,
+    parse_stem,
+)
+
+
+@dataclass(frozen=True)
+class ExportContext:
+    model: str
+    split: str
+    labels_dir: Path
+    images_dir: Path
+
+
+def discover_contexts(repo_root: Path) -> list[ExportContext]:
+    export_root = repo_root / "data" / "10_export"
+    datasets_root = repo_root / "data" / "01_raw" / "datasets"
+    if not export_root.is_dir():
+        return []
+    found: list[ExportContext] = []
+    for model_dir in sorted(p for p in export_root.iterdir() if p.is_dir()):
+        for split_dir in sorted(p for p in model_dir.iterdir() if p.is_dir()):
+            labels_dir = split_dir / "labels"
+            images_dir = datasets_root / split_dir.name / "images"
+            if labels_dir.is_dir():
+                found.append(
+                    ExportContext(
+                        model=model_dir.name,
+                        split=split_dir.name,
+                        labels_dir=labels_dir,
+                        images_dir=images_dir,
+                    )
+                )
+    return found
+
+
+def list_stems(labels_dir: Path) -> list[str]:
+    return sorted(p.stem for p in labels_dir.glob("*.txt"))
+
+
+def parse_yolo_label(path: Path) -> list[dict]:
+    bboxes: list[dict] = []
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) != 5:
+            raise ValueError(f"malformed YOLO line in {path}: {raw!r}")
+        class_id = int(parts[0])
+        cx, cy, w, h = (float(x) for x in parts[1:])
+        bboxes.append({"class_id": class_id, "cx": cx, "cy": cy, "w": w, "h": h})
+    return bboxes
+
+
+def create_app(*, contexts: list[ExportContext]) -> FastAPI:
+    by_key = {(c.model, c.split): c for c in contexts}
+    images_by_split = {c.split: c.images_dir for c in contexts}
+
+    def _ctx(model: str, split: str) -> ExportContext:
+        key = (model, split)
+        if key not in by_key:
+            raise HTTPException(404, f"unknown context: {key}")
+        return by_key[key]
+
+    app = FastAPI()
+
+    @app.get("/api/contexts")
+    def get_contexts() -> dict:
+        items = [
+            {
+                "model": c.model,
+                "split": c.split,
+                "count": len(list(c.labels_dir.glob("*.txt"))),
+            }
+            for c in contexts
+        ]
+        return {"items": items}
+
+    @app.get("/api/frames")
+    def get_frames(model: str, split: str) -> dict:
+        ctx = _ctx(model, split)
+        stems = list_stems(ctx.labels_dir)
+        seq_by_stem = assign_temporal_sequences(stems)
+        groups: dict[str, list[tuple[str, str]]] = {}
+        for stem in stems:
+            _, ts = parse_stem(stem)
+            groups.setdefault(seq_by_stem[stem], []).append((ts, stem))
+        items = []
+        for seq_id, frames in groups.items():
+            frames.sort()
+            items.append(
+                {
+                    "sequence_id": seq_id,
+                    "stems": [s for _, s in frames],
+                }
+            )
+        items.sort(key=lambda g: g["sequence_id"])
+        return {"sequences": items}
+
+    @app.get("/api/sample")
+    def get_sample(model: str, split: str, stem: str) -> dict:
+        ctx = _ctx(model, split)
+        label_path = ctx.labels_dir / f"{stem}.txt"
+        if not label_path.is_file():
+            raise HTTPException(404, f"unknown stem: {stem}")
+        image_path = ctx.images_dir / f"{stem}.jpg"
+        return {
+            "stem": stem,
+            "bboxes": parse_yolo_label(label_path),
+            "image_available": image_path.is_file(),
+        }
+
+    @app.get("/image")
+    def get_image(split: str, stem: str) -> FileResponse:
+        images_dir = images_by_split.get(split)
+        if images_dir is None:
+            raise HTTPException(404, f"unknown split: {split}")
+        path = images_dir / f"{stem}.jpg"
+        if not path.is_file():
+            raise HTTPException(404, f"missing image: {stem}")
+        return FileResponse(path, media_type="image/jpeg")
+
+    static_dir = Path(__file__).parent / "static"
+    if static_dir.is_dir():
+        app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
+
+    return app

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/export_viewer/static/index.html
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/export_viewer/static/index.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Export viewer — frame-level data quality</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0f1115;
+        --panel: #161a22;
+        --border: #2a2f3a;
+        --text: #e6e9ef;
+        --muted: #8a93a6;
+        --accent: #4ea1ff;
+        --bbox: #ff5d5d;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        display: grid;
+        grid-template-columns: 320px 1fr;
+        height: 100vh;
+      }
+      #sidebar {
+        background: var(--panel);
+        border-right: 1px solid var(--border);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      #sidebar header {
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border);
+      }
+      #sidebar header h1 {
+        font-size: 13px;
+        margin: 0 0 8px;
+        font-weight: 600;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      #context-select {
+        width: 100%;
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--border);
+        padding: 6px 8px;
+        border-radius: 4px;
+        font-size: 13px;
+      }
+      #frame-count {
+        font-size: 12px;
+        color: var(--muted);
+        margin-top: 6px;
+      }
+      #frame-list {
+        overflow-y: auto;
+        flex: 1;
+        padding: 4px 0;
+      }
+      .seq-group { margin-bottom: 4px; }
+      .seq-header {
+        padding: 6px 14px 4px;
+        font-size: 11px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        position: sticky;
+        top: 0;
+        background: var(--panel);
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        justify-content: space-between;
+        gap: 8px;
+      }
+      .seq-header .seq-id {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .seq-header .seq-count { flex-shrink: 0; }
+      .frame-item {
+        padding: 4px 14px 4px 24px;
+        font-size: 12px;
+        cursor: pointer;
+        border-left: 3px solid transparent;
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .frame-item:hover { background: rgba(255, 255, 255, 0.04); }
+      .frame-item.active {
+        background: rgba(78, 161, 255, 0.12);
+        border-left-color: var(--accent);
+        color: var(--accent);
+      }
+      #viewer {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+      #viewer header {
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        gap: 16px;
+        align-items: baseline;
+        font-size: 13px;
+      }
+      #stem-label {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 13px;
+      }
+      #meta { color: var(--muted); font-size: 12px; }
+      #canvas-wrap {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+        padding: 16px;
+      }
+      #canvas {
+        max-width: 100%;
+        max-height: 100%;
+        border: 1px solid var(--border);
+        background: #000;
+      }
+      #empty {
+        color: var(--muted);
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <aside id="sidebar">
+      <header>
+        <h1>Export</h1>
+        <select id="context-select"></select>
+        <div id="frame-count"></div>
+      </header>
+      <div id="frame-list"></div>
+    </aside>
+    <main id="viewer">
+      <header>
+        <div id="stem-label">—</div>
+        <div id="meta"></div>
+      </header>
+      <div id="canvas-wrap">
+        <canvas id="canvas"></canvas>
+        <div id="empty" hidden>Select a frame to view</div>
+      </div>
+    </main>
+    <script>
+      const CLASS_NAMES = { 0: "smoke" };
+
+      const state = {
+        contexts: [],
+        current: null,
+        stems: [],
+        stem: null,
+      };
+
+      const contextSelect = document.getElementById("context-select");
+      const frameList = document.getElementById("frame-list");
+      const frameCount = document.getElementById("frame-count");
+      const stemLabel = document.getElementById("stem-label");
+      const meta = document.getElementById("meta");
+      const canvas = document.getElementById("canvas");
+      const canvasWrap = document.getElementById("canvas-wrap");
+      const empty = document.getElementById("empty");
+      const ctx2d = canvas.getContext("2d");
+
+      async function fetchJson(url) {
+        const r = await fetch(url);
+        if (!r.ok) throw new Error(`${r.status} ${r.statusText}: ${url}`);
+        return r.json();
+      }
+
+      function fmtContext(c) {
+        return `${c.model} / ${c.split} (${c.count})`;
+      }
+
+      async function init() {
+        const { items } = await fetchJson("/api/contexts");
+        state.contexts = items;
+        if (!items.length) {
+          frameCount.textContent = "No exports found under data/10_export/";
+          return;
+        }
+        contextSelect.innerHTML = items
+          .map((c, i) => `<option value="${i}">${fmtContext(c)}</option>`)
+          .join("");
+        contextSelect.addEventListener("change", () => {
+          selectContext(Number(contextSelect.value));
+        });
+        await selectContext(0);
+      }
+
+      async function selectContext(index) {
+        state.current = state.contexts[index];
+        const { sequences } = await fetchJson(
+          `/api/frames?model=${encodeURIComponent(state.current.model)}` +
+            `&split=${encodeURIComponent(state.current.split)}`,
+        );
+        state.stems = sequences.flatMap((g) => g.stems);
+        frameCount.textContent =
+          `${state.stems.length} frame${state.stems.length === 1 ? "" : "s"}` +
+          ` · ${sequences.length} sequence${sequences.length === 1 ? "" : "s"}`;
+        frameList.innerHTML = sequences
+          .map(
+            (g) => `
+              <div class="seq-group">
+                <div class="seq-header">
+                  <span class="seq-id" title="${g.sequence_id}">${g.sequence_id}</span>
+                  <span class="seq-count">${g.stems.length}</span>
+                </div>
+                ${g.stems
+                  .map(
+                    (s) =>
+                      `<div class="frame-item" data-stem="${s}">${stemSuffix(s)}</div>`,
+                  )
+                  .join("")}
+              </div>
+            `,
+          )
+          .join("");
+        frameList.querySelectorAll(".frame-item").forEach((el) => {
+          el.addEventListener("click", () => selectStem(el.dataset.stem));
+        });
+        if (state.stems.length) await selectStem(state.stems[0]);
+        else {
+          stemLabel.textContent = "—";
+          meta.textContent = "";
+          empty.hidden = false;
+          canvas.hidden = true;
+        }
+      }
+
+      function stemSuffix(stem) {
+        const i = stem.lastIndexOf("_");
+        return i === -1 ? stem : stem.slice(i + 1);
+      }
+
+      async function selectStem(stem) {
+        state.stem = stem;
+        frameList.querySelectorAll(".frame-item").forEach((el) => {
+          el.classList.toggle("active", el.dataset.stem === stem);
+        });
+        const active = frameList.querySelector(".frame-item.active");
+        if (active) active.scrollIntoView({ block: "nearest" });
+
+        const sample = await fetchJson(
+          `/api/sample?model=${encodeURIComponent(state.current.model)}` +
+            `&split=${encodeURIComponent(state.current.split)}` +
+            `&stem=${encodeURIComponent(stem)}`,
+        );
+        stemLabel.textContent = stem;
+        meta.textContent = `${sample.bboxes.length} bbox${
+          sample.bboxes.length === 1 ? "" : "es"
+        }${sample.image_available ? "" : " — image missing"}`;
+
+        if (!sample.image_available) {
+          canvas.hidden = true;
+          empty.hidden = false;
+          empty.textContent = `Image not found: data/01_raw/datasets/${state.current.split}/images/${stem}.jpg`;
+          return;
+        }
+        empty.hidden = true;
+        canvas.hidden = false;
+        await draw(stem, sample.bboxes);
+      }
+
+      function draw(stem, bboxes) {
+        return new Promise((resolve, reject) => {
+          const img = new Image();
+          img.onload = () => {
+            canvas.width = img.naturalWidth;
+            canvas.height = img.naturalHeight;
+            ctx2d.drawImage(img, 0, 0);
+            ctx2d.strokeStyle = "#ff5d5d";
+            ctx2d.lineWidth = Math.max(2, img.naturalWidth / 600);
+            ctx2d.font = `${Math.max(12, img.naturalWidth / 100)}px ui-monospace, monospace`;
+            ctx2d.fillStyle = "#ff5d5d";
+            for (const b of bboxes) {
+              const x = (b.cx - b.w / 2) * img.naturalWidth;
+              const y = (b.cy - b.h / 2) * img.naturalHeight;
+              const w = b.w * img.naturalWidth;
+              const h = b.h * img.naturalHeight;
+              ctx2d.strokeRect(x, y, w, h);
+              const label = CLASS_NAMES[b.class_id] ?? String(b.class_id);
+              ctx2d.fillText(label, x, Math.max(y - 4, 12));
+            }
+            fitCanvas();
+            resolve();
+          };
+          img.onerror = reject;
+          img.src = `/image?split=${encodeURIComponent(state.current.split)}&stem=${encodeURIComponent(stem)}`;
+        });
+      }
+
+      function fitCanvas() {
+        const wrapW = canvasWrap.clientWidth - 32;
+        const wrapH = canvasWrap.clientHeight - 32;
+        const scale = Math.min(wrapW / canvas.width, wrapH / canvas.height, 1);
+        canvas.style.width = `${canvas.width * scale}px`;
+        canvas.style.height = `${canvas.height * scale}px`;
+      }
+
+      window.addEventListener("resize", () => {
+        if (canvas.width) fitCanvas();
+      });
+
+      window.addEventListener("keydown", (e) => {
+        if (!state.stems.length) return;
+        const idx = state.stems.indexOf(state.stem);
+        if (e.key === "ArrowDown" || e.key === "j") {
+          e.preventDefault();
+          selectStem(state.stems[Math.min(idx + 1, state.stems.length - 1)]);
+        } else if (e.key === "ArrowUp" || e.key === "k") {
+          e.preventDefault();
+          selectStem(state.stems[Math.max(idx - 1, 0)]);
+        }
+      });
+
+      init().catch((err) => {
+        frameCount.textContent = `Error: ${err.message}`;
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- New read-only browser viewer for `data/10_export/<model>/<split>/labels/`: overlays the corrected YOLO boxes on the source image from `data/01_raw/datasets/<split>/images/`.
- Sidebar groups frames by temporal sequence (reuses `audit_app.sequence.assign_temporal_sequences`) and renames class id `0` to `smoke` in the overlay.
- Launched via `make export-viewer` on http://localhost:8001 (FastAPI + uvicorn, `audit-app` dependency group).

## Test plan
- [x] `make export-viewer`, open http://localhost:8001, switch between (model, split) contexts in the sidebar selector.
- [x] Confirm sequences group correctly and frame count + sequence count match the export.
- [x] Verify bboxes render on the image with the `smoke` label, and that j/k / arrow keys navigate frames.
- [x] `make lint` passes.