### PR TITLE
feat(data-quality/frame-level): re-run predict against v4.0.0 datasets

### DIFF
--- a/experiments/data-quality/frame-level/dvc.lock
+++ b/experiments/data-quality/frame-level/dvc.lock
@@ -56,8 +56,8 @@ stages:
     outs:
     - path: data/07_model_output/yolo11s-nimble-narwhal/train
       hash: md5
-      md5: 58f829ccaa0223a7ec992df76087d18e.dir
-      size: 6524018
+      md5: 2ceccf0d2632f73a1afc8f6b89a79866.dir
+      size: 6561781
       nfiles: 1
   predict_val@yolo11s-nimble-narwhal:
     cmd: uv run python scripts/predict.py --model-name yolo11s-nimble-narwhal 
@@ -96,8 +96,8 @@ stages:
     outs:
     - path: data/07_model_output/yolo11s-nimble-narwhal/val
       hash: md5
-      md5: 2ec65bc2dd57b385356fd5867a5e8810.dir
-      size: 642956
+      md5: 1f2bd48b346db3d0c1d61717516b3e46.dir
+      size: 644787
       nfiles: 1
   predict_test@yolo11s-nimble-narwhal:
     cmd: uv run python scripts/predict.py --model-name yolo11s-nimble-narwhal 
@@ -136,6 +136,6 @@ stages:
     outs:
     - path: data/07_model_output/yolo11s-nimble-narwhal/test
       hash: md5
-      md5: e3213251e4572c88d6111a05796e6d28.dir
-      size: 901804
+      md5: 112faa9554a99c0dcc5fcdd39c9a9a00.dir
+      size: 904020
       nfiles: 1


### PR DESCRIPTION
Stacked on top of #63.

## Summary
- Re-run `predict_train/val/test@yolo11s-nimble-narwhal` with `dvc repro -fs` against the self-hosted v4.0.0 raw datasets introduced in #63.
- Updates `data/07_model_output/yolo11s-nimble-narwhal/{train,val,test}/predictions.json` to reflect the ~3-file drift per split between the previous v3-era predict state and v4.0.0.
- DVC-pushed to `s3://pyro-vision-rd/...` (6 blobs).

## Why
After #63 swapped the raw datasets to self-hosted v4.0.0, `dvc commit` reconciled the predict deps in `dvc.lock` without re-running predict. The predict outputs remained from the older dataset state. This PR brings predictions back in sync with the dataset they're declared to depend on.

## What does NOT change
- Reviewer work in `data/09_review/yolo11s-nimble-narwhal/<split>/review.json` is preserved. The audit-app reads predictions and review state independently (`predictions.keys() | gt.keys()` builds the universe; review is keyed by stem and never auto-deleted).
- Existing reviewed stems whose images haven't changed will see byte-identical predictions (YOLO inference is deterministic on identical inputs, same model, same library version). Only the ~3 actually-changed samples per split produce different predictions.
- 2 latent orphan review entries in val (stems removed in v4.0.0) remain — they were already orphans before this PR and stay dormant in `review.json` (audit-app doesn't surface them). Pruning is intentionally out of scope.

## Test plan
- [x] Merge after #63
- [x] `uv run dvc pull` on a fresh clone → all three predict output dirs materialize
- [x] `make audit-app` → val queue still shows reviewed work; any new/changed samples appear pending