### PR TITLE
feat(audit-app): hide fully-annotated sequences by default

### DIFF
--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
@@ -3,13 +3,33 @@ const state = {
   view: 'fp',
   conf: 0.05, iou: 0.05, reviewConf: 0.35,
   showOrig: true, showPred: true, showOnlyVerified: false,
+  showAnnotated: localStorage.getItem('show_annotated') === '1',
   reviewer: localStorage.getItem('reviewer') || '',
-  queue: [], queueIndex: -1,
+  queueRaw: [], queue: [], queueIndex: -1,
   sample: null,
   dirty: false,
   loadedSnapshot: null,
   undoStack: [],
 };
+
+function filterQueueForView(items, showAnnotated) {
+  if (showAnnotated) return items.slice();
+  const flaggedBySeq = new Map();
+  const doneBySeq = new Map();
+  items.forEach(it => {
+    if (it.kind && it.kind !== 'none') {
+      flaggedBySeq.set(it.sequence_id, (flaggedBySeq.get(it.sequence_id) || 0) + 1);
+      if (it.status === 'reviewed' || it.status === 'unclear') {
+        doneBySeq.set(it.sequence_id, (doneBySeq.get(it.sequence_id) || 0) + 1);
+      }
+    }
+  });
+  const hiddenSeqs = new Set();
+  for (const [seq, flagged] of flaggedBySeq) {
+    if ((doneBySeq.get(seq) || 0) >= flagged) hiddenSeqs.add(seq);
+  }
+  return items.filter(it => !hiddenSeqs.has(it.sequence_id));
+}
 
 const api = {
   contexts: () => fetch('/api/contexts').then(r => r.json()),
@@ -145,6 +165,15 @@ async function init() {
       reloadQueue();
     });
   });
+  const annotatedBtn = document.getElementById('show-annotated');
+  const syncAnnotatedBtn = () => annotatedBtn.classList.toggle('active', state.showAnnotated);
+  syncAnnotatedBtn();
+  annotatedBtn.addEventListener('click', async () => {
+    state.showAnnotated = !state.showAnnotated;
+    localStorage.setItem('show_annotated', state.showAnnotated ? '1' : '0');
+    syncAnnotatedBtn();
+    await applyQueueFilter();
+  });
   document.getElementById('show-orig').addEventListener('change', e => {
     state.showOrig = e.target.checked; paint();
   });
@@ -218,7 +247,13 @@ async function reloadQueue() {
     model: state.model, split: state.split, view: state.view,
     conf: state.conf, iou: state.iou, reviewConf: state.reviewConf,
   });
-  state.queue = r.items;
+  state.queueRaw = r.items;
+  await applyQueueFilter();
+}
+
+async function applyQueueFilter() {
+  await flushPending();
+  state.queue = filterQueueForView(state.queueRaw, state.showAnnotated);
   state.queueIndex = state.queue.length > 0 ? 0 : -1;
   renderQueue();
   renderProgress();
@@ -227,7 +262,7 @@ async function reloadQueue() {
 }
 
 function renderProgress() {
-  const flagged = state.queue.filter(i => i.kind && i.kind !== 'none');
+  const flagged = state.queueRaw.filter(i => i.kind && i.kind !== 'none');
   const reviewed = flagged.filter(i => i.status === 'reviewed').length;
   const total = flagged.length;
   const pct = total > 0 ? (reviewed / total) * 100 : 0;

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
@@ -169,10 +169,17 @@ async function init() {
   const syncAnnotatedBtn = () => annotatedBtn.classList.toggle('active', state.showAnnotated);
   syncAnnotatedBtn();
   annotatedBtn.addEventListener('click', async () => {
+    await flushPending();
     state.showAnnotated = !state.showAnnotated;
     localStorage.setItem('show_annotated', state.showAnnotated ? '1' : '0');
     syncAnnotatedBtn();
-    await applyQueueFilter();
+    const prevStem = state.sample?.stem ?? null;
+    applyQueueFilter();
+    if (state.queueIndex < 0) {
+      state.sample = null; paint(); renderRight(); renderTimeline();
+    } else if (state.queue[state.queueIndex].stem !== prevStem) {
+      await loadSample(state.queue[state.queueIndex].stem);
+    }
   });
   document.getElementById('show-orig').addEventListener('change', e => {
     state.showOrig = e.target.checked; paint();
@@ -248,27 +255,28 @@ async function reloadQueue() {
     conf: state.conf, iou: state.iou, reviewConf: state.reviewConf,
   });
   state.queueRaw = r.items;
-  await applyQueueFilter();
+  applyQueueFilter();
+  if (state.queueIndex >= 0) await loadSample(state.queue[state.queueIndex].stem);
+  else { state.sample = null; paint(); renderRight(); renderTimeline(); }
 }
 
-async function applyQueueFilter() {
-  await flushPending();
+function applyQueueFilter() {
+  const prevStem = state.sample?.stem ?? null;
   state.queue = filterQueueForView(state.queueRaw, state.showAnnotated);
-  state.queueIndex = state.queue.length > 0 ? 0 : -1;
+  const preserved = prevStem ? state.queue.findIndex(q => q.stem === prevStem) : -1;
+  state.queueIndex = preserved >= 0 ? preserved : (state.queue.length > 0 ? 0 : -1);
   renderQueue();
   renderProgress();
-  if (state.queueIndex >= 0) await loadSample(state.queue[0].stem);
-  else { state.sample = null; paint(); renderRight(); renderTimeline(); }
 }
 
 function renderProgress() {
   const flagged = state.queueRaw.filter(i => i.kind && i.kind !== 'none');
-  const reviewed = flagged.filter(i => i.status === 'reviewed').length;
+  const done = flagged.filter(i => i.status === 'reviewed' || i.status === 'unclear').length;
   const total = flagged.length;
-  const pct = total > 0 ? (reviewed / total) * 100 : 0;
+  const pct = total > 0 ? (done / total) * 100 : 0;
   const root = document.getElementById('progress');
   root.querySelector('.fill').style.width = `${pct}%`;
-  root.querySelector('.label').textContent = `${reviewed} / ${total}`;
+  root.querySelector('.label').textContent = `${done} / ${total}`;
 }
 
 function renderQueue() {

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
@@ -138,6 +138,7 @@
       <button data-view="fp" class="chip active">FP</button>
       <button data-view="fn" class="chip">FN</button>
     </span>
+    <button id="show-annotated" title="Show sequences whose flagged frames are all reviewed or unclear" class="chip">show annotated</button>
     <div id="progress" title="Reviewed / total in current FP/FN queue" class="flex min-w-[200px] items-center gap-2">
       <div class="bar h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
         <div class="fill h-full rounded-full bg-gradient-to-r from-emerald-400 to-emerald-600 transition-all duration-300" style="width: 0"></div>

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
@@ -139,7 +139,7 @@
       <button data-view="fn" class="chip">FN</button>
     </span>
     <button id="show-annotated" title="Show sequences whose flagged frames are all reviewed or unclear" class="chip">show annotated</button>
-    <div id="progress" title="Reviewed / total in current FP/FN queue" class="flex min-w-[200px] items-center gap-2">
+    <div id="progress" title="Annotated (reviewed or unclear) / total flagged frames in current view" class="flex min-w-[200px] items-center gap-2">
       <div class="bar h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
         <div class="fill h-full rounded-full bg-gradient-to-r from-emerald-400 to-emerald-600 transition-all duration-300" style="width: 0"></div>
       </div>


### PR DESCRIPTION
- Add a `show annotated` chip next to the FP/FN view chips. Off by default; toggles whether sequences whose flagged frames are all reviewed or unclear appear in the queue.
- Choice persists across sessions via `localStorage`. Current stem is preserved on toggle when still visible.
- Progress counter now treats `reviewed` and `unclear` consistently as "done" to match the filter semantics; tooltip updated.