### PR TITLE
review(test): bbox corrections + export for yolo11s-nimble-narwhal

### DIFF
--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 18aa1d526ec000daf162c9aa8a9fd956.dir
-  size: 9992
+- md5: 8841dcadb4dd88ce988b76798846c69c.dir
+  size: 95147
   nfiles: 1
   hash: md5
   path: test

--- a/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/09_review/yolo11s-nimble-narwhal/test.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 8841dcadb4dd88ce988b76798846c69c.dir
-  size: 95147
+- md5: f2784f81e70461adfda501b76f8b9222.dir
+  size: 148546
   nfiles: 1
   hash: md5
   path: test

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 5c11247bff6241a89ce3cc40e78cff30.dir
-  size: 1131
-  nfiles: 4
+- md5: a38e258d6a5c13cca5f48f3e6b0abb1b.dir
+  size: 17033
+  nfiles: 48
   hash: md5
   path: test

--- a/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
+++ b/experiments/data-quality/frame-level/data/10_export/yolo11s-nimble-narwhal/test.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: a38e258d6a5c13cca5f48f3e6b0abb1b.dir
-  size: 17033
-  nfiles: 48
+- md5: dea3577b44a2418dcce0521395a5f4b8.dir
+  size: 28679
+  nfiles: 82
   hash: md5
   path: test


### PR DESCRIPTION
## Summary
- Audit of frame-level test split for the `yolo11s-nimble-narwhal` model
- Updates DVC pointers for `data/09_review/yolo11s-nimble-narwhal/test` (bbox corrections) and `data/10_export/yolo11s-nimble-narwhal/test` (re-exported artifacts)

## Test Plan
- [x] `dvc pull` the updated `09_review/test` and `10_export/test` artifacts
- [x] Spot-check corrected bboxes in the review tool
- [x] Verify export integrity (counts, label distribution) matches the reviewed set