### PR TITLE
feat(audit-app): add reset zoom & pan button

### DIFF
--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
@@ -57,6 +57,7 @@ let drag = null;
 let hovered = null;
 let zoom = 1, panX = 0, panY = 0;
 let imgNaturalW = 0, imgNaturalH = 0;
+let viewMoved = false;
 
 function ensureReviewer() {
   if (state.reviewer) {
@@ -189,6 +190,9 @@ async function init() {
   });
   document.getElementById('show-only-verified').addEventListener('change', e => {
     state.showOnlyVerified = e.target.checked; paint();
+  });
+  document.getElementById('reset-view').addEventListener('click', () => {
+    resetView(); paint();
   });
   const helpPane = document.getElementById('help-pane');
   const toggleHelp = () => { helpPane.hidden = !helpPane.hidden; };
@@ -460,6 +464,13 @@ function resetView() {
   zoom = Math.min(cnv.width / imgNaturalW, cnv.height / imgNaturalH);
   panX = (cnv.width - imgNaturalW * zoom) / 2;
   panY = (cnv.height - imgNaturalH * zoom) / 2;
+  viewMoved = false;
+}
+
+function updateResetBtn() {
+  const btn = document.getElementById('reset-view');
+  if (!btn) return;
+  btn.hidden = !viewMoved;
 }
 
 function clampPan() {
@@ -477,6 +488,7 @@ function screenToWorld(clientX, clientY) {
 }
 
 function paint() {
+  updateResetBtn();
   if (!state.sample || !imgLoaded) {
     ctx2d.clearRect(0, 0, cnv.width || 1, cnv.height || 1);
     return;
@@ -621,6 +633,7 @@ cnv.addEventListener('mousemove', e => {
     panX = drag.startPan.x + (e.clientX - drag.startScreen.x);
     panY = drag.startPan.y + (e.clientY - drag.startScreen.y);
     clampPan();
+    viewMoved = true;
     paint();
     return;
   }
@@ -685,6 +698,7 @@ cnv.addEventListener('wheel', e => {
   panY = sy - wy * newZoom;
   zoom = newZoom;
   clampPan();
+  viewMoved = true;
   paint();
 }, { passive: false });
 
@@ -1045,7 +1059,11 @@ async function setStatusAndAdvance(s) {
 }
 
 window.addEventListener('resize', () => {
-  if (imgLoaded && state.sample) { sizeCanvas(); clampPan(); paint(); }
+  if (!imgLoaded || !state.sample) return;
+  const wasMoved = viewMoved;
+  sizeCanvas();
+  if (wasMoved) clampPan(); else resetView();
+  paint();
 });
 
 window.addEventListener('DOMContentLoaded', init);

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
@@ -198,10 +198,11 @@
     <section class="flex flex-1 min-w-0 flex-col bg-slate-900">
       <div id="canvas-wrap" class="relative flex flex-1 items-center justify-center p-4">
         <canvas id="cnv" class="max-h-full max-w-full cursor-crosshair rounded shadow-2xl ring-1 ring-slate-800"></canvas>
-        <div id="layer-toggles" class="absolute right-3 top-3 flex gap-3 rounded-md bg-slate-900/70 px-3 py-1.5 text-xs text-slate-200 backdrop-blur-sm">
+        <div id="layer-toggles" class="absolute right-3 top-3 flex items-center gap-3 rounded-md bg-slate-900/70 px-3 py-1.5 text-xs text-slate-200 backdrop-blur-sm">
           <label class="flex items-center gap-1.5"><input type="checkbox" id="show-orig" checked class="accent-sky-400"> O · original ground truth</label>
           <label class="flex items-center gap-1.5"><input type="checkbox" id="show-pred" checked class="accent-rose-400"> P · predictions</label>
           <label class="flex items-center gap-1.5"><input type="checkbox" id="show-only-verified" class="accent-emerald-400"> V · verified only (export preview)</label>
+          <button id="reset-view" hidden title="Reset zoom &amp; pan to fit the image (0)" class="flex items-center gap-1 rounded border border-slate-700 bg-slate-800/70 px-2 py-0.5 text-slate-200 transition hover:border-sky-400 hover:bg-sky-500/20 hover:text-sky-200">⤾ Reset zoom &amp; pan (0)</button>
         </div>
       </div>
       <div id="timeline" class="flex min-h-[140px] gap-2 overflow-x-auto border-t border-slate-800 bg-slate-950 px-3 py-3 text-slate-400"></div>


### PR DESCRIPTION
## Summary
- Adds a `⤾ Reset zoom & pan (0)` button in the canvas layer-toggles overlay (audit app). Visible **only when the user has zoomed or panned away from fit**; clicking it returns to the initial fitted view.
- The existing `0` keyboard shortcut continues to work and is already documented in the help pane.
- Tracks user intent with a simple `viewMoved` flag (set by wheel zoom and shift-drag pan, cleared by `resetView()`) rather than value-comparing the transform — robust to canvas re-layouts and floating-point drift.
- On window resize, if the user hadn't moved the view, re-fit instead of just clamping pan, so the image keeps fitting as the viewport changes.

<img width="753" height="42" alt="image" src="https://github.com/user-attachments/assets/37093531-7b14-4644-8284-79b20c258337" />


## Test plan
- [ ] `make audit-app`, open a sample.
- [ ] Reset button hidden on fresh load (no zoom/pan).
- [ ] Wheel zoom → button appears. Click it → image refits, button hides.
- [ ] Shift-drag pan → button appears. Press `0` → image refits, button hides.
- [ ] Resize the window without zooming/panning → image stays fitted, button stays hidden.
- [ ] Resize after zooming/panning → user's view preserved (clamped), button stays visible.
- [ ] Navigate between samples (`←`/`→`) after zooming → view preserved (existing `preserveView` behaviour, unchanged).