### PR TITLE
feat(audit-app): containment-based matching to shrink the FP queue

### DIFF
--- a/experiments/data-quality/frame-level/docs/specs/2026-05-15-audit-app-containment-matching-design.md
+++ b/experiments/data-quality/frame-level/docs/specs/2026-05-15-audit-app-containment-matching-design.md
@@ -1,0 +1,183 @@
+# Audit-app containment matching — design
+
+**Status:** draft
+**Date:** 2026-05-15
+**Owner:** Arthur
+
+## 1. Background
+
+The frame-level audit app surfaces candidate label errors by running
+the production YOLO detector against the dataset GT, classifying each
+prediction as TP / FP / FN, and queuing frames that contain at least
+one FP or FN.
+
+The classifier today lives in
+`src/data_quality_frame_level/audit_app/matching.py`. It is a
+single-class greedy IoU matcher: all `(gt, pred)` pairs are sorted by
+descending IoU and walked in order; each GT and each pred can be
+matched at most once. Unmatched preds become FP, unmatched GT becomes
+FN.
+
+The per-frame severity used by the queue (`audit_app/queue.py`) is the
+max confidence among preds labelled `fp` (filtered by
+`review_conf_thresh`) or the max area among GTs labelled `fn`, and
+sequences are ordered by their max severity.
+
+## 2. Problem
+
+On the train split — by far the largest of the three — the FP queue is
+dominated by frames where the model emitted 2–3 overlapping boxes for
+a single real smoke plume. Under greedy-1-to-1 IoU matching:
+
+- The highest-IoU pred claims the GT and is labelled TP.
+- The remaining preds for the same plume cannot match (the GT is
+  already taken) and are labelled FP.
+- The frame surfaces in the FP queue even though the model's detection
+  is semantically correct.
+
+A second, related shortcoming: a tight pred sitting inside a generous
+GT label has low IoU (large union, small intersection) and so falls
+below `iou_thresh`. It becomes FP despite being squarely on the smoke.
+
+These two patterns inflate the train queue with frames that have no
+actionable label-quality issue, increasing reviewer fatigue and time
+to completion.
+
+## 3. Goals
+
+- Stop surfacing frames whose only FPs are duplicate or tight-inside
+  predictions over a real GT.
+- Keep surfacing frames with genuinely mislocated predictions (preds
+  that overlap nothing real) and genuine misses (GTs with no matching
+  pred).
+- Make the change a tunable knob in the UI so a reviewer can dial it
+  back per session if needed.
+- Leave persisted review state and past exports untouched.
+
+## 4. Non-goals
+
+- No new diagnostic view for oversized GT labels. (Discussed; deferred.)
+- No change to FN semantics. A GT is FN iff no pred agrees with it.
+- No change to the export flow (`audit_app/export.py`, `data/10_export/`)
+  or the review state schema (`review.json`).
+- No change to predictions on disk (`data/07_model_output/`); only the
+  in-memory classification of those predictions changes.
+
+## 5. Design
+
+### 5.1 New matcher: many-to-one + optional containment
+
+Replace the greedy 1-to-1 matcher in
+`audit_app/matching.py:evaluate_frame` with an independent-decision
+matcher. For each `(gt_i, pred_j)` pair, define an `agrees` predicate:
+
+```
+agrees(gt_i, pred_j) :=
+    IoU(gt_i, pred_j) >= iou_thresh
+ OR (containment_thresh is not None
+     AND IoP(pred_j, gt_i) >= containment_thresh)
+```
+
+where `IoP(pred, gt) = intersection_area / pred_area` — "how much of
+the prediction sits inside this GT box."
+
+Classification:
+
+- `pred_j` is TP iff `any(agrees(gt_i, pred_j) for gt_i in gt)`,
+  else FP.
+- `gt_i` is TP iff `any(agrees(gt_i, pred_j) for pred_j in
+  predictions)`, else FN.
+
+The `matches` field of `EvaluatedFrame` (currently a list of
+greedy-matched `(gi, pj, iou)` tuples) becomes, for each TP-GT, the
+single best-IoU pred that agrees with it. This is internal — no
+consumer outside `matching.py` reads it today — but keeping the field
+preserves its usefulness for future visual association in the right
+pane.
+
+### 5.2 Default containment threshold
+
+`containment_thresh = 0.7` is the default. Rationale:
+
+- Literature-standard threshold for containment-based matching.
+- Strict enough that a pred drifting half outside the GT stays an FP.
+- Lenient enough to absorb the typical smoke pattern: tight pred
+  inside a generous plume label.
+
+### 5.3 Plumbing
+
+| File | Change |
+|---|---|
+| `audit_app/matching.py` | Add `iop()` helper. Rewrite `evaluate_frame` per 5.1. New keyword `containment_thresh: float \| None = None`. Update module docstring. |
+| `audit_app/queue.py` | Thread `containment_thresh` through `build_queue` and `_frame_severity`. Default `0.7`. |
+| `audit_app/main.py` | Add `containment: float \| None = 0.7` query parameter to `GET /api/queue` and `GET /api/sample`. Pass through to `build_queue` and `evaluate_frame`. |
+| `audit_app/static/index.html` | Add a fourth row in the filter panel beside `conf`, `iou`, `review`, labelled `contain ≥`, range `0–1`, step `0.05`, `value="0.7"`. |
+| `audit_app/static/app.js` | Read the new slider in the queue and sample fetch builders; include it in the `filter-reset` defaults. When the slider reads `0`, send `containment=null` to the API. |
+| `tests/test_matching.py` | Add focused unit tests (see 5.5). |
+
+### 5.4 Slider semantics
+
+Range 0.0–1.0, step 0.05, initial value 0.7. A value of `0` is the
+"off" sentinel: the UI sends `containment=null` and the server matches
+on IoU only. Any value `> 0` engages containment with that
+threshold. Default reset returns the slider to 0.7.
+
+### 5.5 Tests
+
+Four focused unit tests in `tests/test_matching.py`:
+
+1. **Duplicate preds over one GT** — 3 preds with high overlap on a
+   single GT. Expect all 3 preds TP, GT TP, no FP, no FN.
+2. **Tight pred inside generous GT (low IoU, high IoP)** — one pred
+   that meets `containment_thresh` but not `iou_thresh`. Expect TP.
+3. **Giant pred over two GTs (low IoU, low IoP)** — one large pred
+   covering two small adjacent GTs, where IoU and IoP both fall below
+   their thresholds against each GT. Expect pred FP, both GTs FN.
+4. **`containment_thresh=None`** — pure-IoU many-to-one fallback. A
+   tight pred with low IoU is FP; duplicate preds passing `iou_thresh`
+   are all TP.
+
+## 6. Risks
+
+1. **Giant-pred edge case.** A single huge pred covering two adjacent
+   GTs flips from `TP+FN` under the old matcher to `FP+FN+FN` under
+   the new one. The frame is still surfaced via the FNs in both
+   regimes; only the per-box labels differ. Accepted.
+2. **Threshold calibration.** `0.7` is chosen from literature, not
+   from data. If reviewers find too many real FPs are absorbed, the
+   slider rejects the default per session; if it is systematically
+   wrong, the constant lives in three places (`queue.py`, `main.py`,
+   `index.html`). No data risk — only UX.
+3. **Default duplicated across client and server.** `index.html`
+   `value="0.7"` and the `main.py` query-param default both hardcode
+   the value. This matches the existing pattern for `conf`, `iou`, and
+   `review_conf`, so the convention is consistent, but it is a sharp
+   edge to be aware of when changing the default later.
+
+## 7. Migration / compatibility
+
+None required.
+
+- `review.json` is keyed by stem and stores reviewer decisions, not
+  matching outcomes. It is unaffected by this change.
+- `data/10_export/<model>/<split>/` is derived from
+  `review.samples` and `originals` via
+  `audit_app/export.py:write_manifest_and_labels`; the matcher is not
+  in that path. Past exports remain valid.
+- The audit queue is recomputed per request, so the next page load
+  reflects the new matcher with no migration step.
+
+## 8. Acceptance criteria
+
+- Opening the train split with default thresholds shows a visibly
+  smaller FP queue than today; frames whose only FPs were duplicate
+  boxes on a real GT are absent.
+- Moving the containment slider to `0.0` falls back to many-to-one
+  IoU-only matching, isolating the containment effect.
+- New unit tests in `tests/test_matching.py` cover the four scenarios
+  in 5.5 and pass.
+- Existing tests still pass.
+- `git status` after a fresh review session shows changes only under
+  `data/09_review/` (as today) — no untracked changes under
+  `data/10_export/` or other data directories that this change
+  was not intended to touch.

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/main.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/main.py
@@ -88,6 +88,7 @@ def create_app(
         conf: float,
         iou: float,
         review_conf: float,
+        containment: float = 0.7,
     ) -> dict:
         s = _state(model, split)
         flagged = build_queue(
@@ -99,6 +100,7 @@ def create_app(
             conf_thresh=conf,
             iou_thresh=iou,
             review_conf_thresh=review_conf,
+            containment_thresh=containment if containment > 0 else None,
         )
         flagged_stems = {it.stem for it in flagged}
         flagged_seq_ids = {it.sequence_id for it in flagged}
@@ -138,13 +140,19 @@ def create_app(
         conf: float,
         iou: float,
         review_conf: float,
+        containment: float = 0.7,
     ) -> dict:
         s = _state(model, split)
         if stem not in s.gt and stem not in s.predictions:
             raise HTTPException(404, f"unknown stem: {stem}")
         gt = s.gt.get(stem, [])
         preds = [p for p in s.predictions.get(stem, []) if p.conf >= conf]
-        ev = evaluate_frame(gt=gt, predictions=preds, iou_thresh=iou)
+        ev = evaluate_frame(
+            gt=gt,
+            predictions=preds,
+            iou_thresh=iou,
+            containment_thresh=containment if containment > 0 else None,
+        )
         sample = s.review.samples.get(stem)
         seq_id = s.sequence_id_by_stem[stem]
         _, ts = parse_stem(stem)

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/matching.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/matching.py
@@ -61,9 +61,7 @@ def evaluate_frame(
     def agrees(gi: int, pj: int) -> bool:
         if pair_iou[gi][pj] >= iou_thresh:
             return True
-        if containment_thresh is not None and pair_iop[gi][pj] >= containment_thresh:
-            return True
-        return False
+        return containment_thresh is not None and pair_iop[gi][pj] >= containment_thresh
 
     pred_status = [
         "tp" if any(agrees(gi, pj) for gi in range(len(gt))) else "fp"

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/matching.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/matching.py
@@ -1,8 +1,11 @@
-"""Per-frame TP / FP / FN assignment using greedy IoU matching.
+"""Per-frame TP / FP / FN assignment via many-to-one matching.
 
-Single-class greedy matcher: predictions and GT are matched greedily
-by descending IoU; unmatched predictions become FP, unmatched GT
-becomes FN.
+Each prediction is TP iff at least one GT agrees with it; each GT is TP
+iff at least one prediction agrees with it. Agreement is a composite
+predicate: ``IoU >= iou_thresh`` OR (when ``containment_thresh`` is
+supplied) ``IoP >= containment_thresh``, where ``IoP`` is
+intersection-over-prediction-area. Pure-IoU matching is recovered by
+passing ``containment_thresh=None`` (the default).
 """
 
 from dataclasses import dataclass
@@ -32,32 +35,58 @@ def iou(a: BBox | Prediction, b: BBox | Prediction) -> float:
     return inter / union if union > 0 else 0.0
 
 
+def iop(pred: BBox | Prediction, gt: BBox | Prediction) -> float:
+    """Intersection over prediction area — 'how much of the pred sits inside the GT?'"""
+    px1, py1 = pred.cx - pred.w / 2, pred.cy - pred.h / 2
+    px2, py2 = pred.cx + pred.w / 2, pred.cy + pred.h / 2
+    gx1, gy1 = gt.cx - gt.w / 2, gt.cy - gt.h / 2
+    gx2, gy2 = gt.cx + gt.w / 2, gt.cy + gt.h / 2
+    iw = max(0.0, min(px2, gx2) - max(px1, gx1))
+    ih = max(0.0, min(py2, gy2) - max(py1, gy1))
+    inter = iw * ih
+    a = pred.w * pred.h
+    return inter / a if a > 0 else 0.0
+
+
 def evaluate_frame(
     *,
     gt: list[BBox],
     predictions: list[Prediction],
     iou_thresh: float,
+    containment_thresh: float | None = None,
 ) -> EvaluatedFrame:
-    candidates = sorted(
-        (
-            (i, j, iou(g, p))
-            for i, g in enumerate(gt)
-            for j, p in enumerate(predictions)
-        ),
-        key=lambda x: x[2],
-        reverse=True,
-    )
-    matched_gt: set[int] = set()
-    matched_pred: set[int] = set()
+    pair_iou = [[iou(g, p) for p in predictions] for g in gt]
+    pair_iop = [[iop(p, g) for p in predictions] for g in gt]
+
+    def agrees(gi: int, pj: int) -> bool:
+        if pair_iou[gi][pj] >= iou_thresh:
+            return True
+        if containment_thresh is not None and pair_iop[gi][pj] >= containment_thresh:
+            return True
+        return False
+
+    pred_status = [
+        "tp" if any(agrees(gi, pj) for gi in range(len(gt))) else "fp"
+        for pj in range(len(predictions))
+    ]
+    gt_status = [
+        "tp" if any(agrees(gi, pj) for pj in range(len(predictions))) else "fn"
+        for gi in range(len(gt))
+    ]
+
     matches: list[tuple[int, int, float]] = []
-    for gi, pj, score in candidates:
-        if score < iou_thresh:
-            break
-        if gi in matched_gt or pj in matched_pred:
+    for gi, st in enumerate(gt_status):
+        if st != "tp":
             continue
-        matched_gt.add(gi)
-        matched_pred.add(pj)
-        matches.append((gi, pj, score))
-    gt_status = ["tp" if i in matched_gt else "fn" for i in range(len(gt))]
-    pred_status = ["tp" if j in matched_pred else "fp" for j in range(len(predictions))]
+        best = max(
+            (
+                (pj, pair_iou[gi][pj])
+                for pj in range(len(predictions))
+                if agrees(gi, pj)
+            ),
+            key=lambda x: x[1],
+            default=None,
+        )
+        if best is not None:
+            matches.append((gi, best[0], best[1]))
     return EvaluatedFrame(gt_status=gt_status, pred_status=pred_status, matches=matches)

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/queue.py
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/queue.py
@@ -34,9 +34,15 @@ def _frame_severity(
     iou_thresh: float,
     review_conf_thresh: float,
     view: str,
+    containment_thresh: float | None = 0.7,
 ) -> tuple[str | None, float]:
     pred_filt = [p for p in predictions if p.conf >= conf_thresh]
-    ev = evaluate_frame(gt=gt, predictions=pred_filt, iou_thresh=iou_thresh)
+    ev = evaluate_frame(
+        gt=gt,
+        predictions=pred_filt,
+        iou_thresh=iou_thresh,
+        containment_thresh=containment_thresh,
+    )
     fp_conf = max(
         (
             p.conf
@@ -73,6 +79,7 @@ def build_queue(
     conf_thresh: float,
     iou_thresh: float,
     review_conf_thresh: float,
+    containment_thresh: float | None = 0.7,
 ) -> list[QueueItem]:
     items: list[QueueItem] = []
     for stem in sorted(predictions.keys() | gt.keys()):
@@ -83,6 +90,7 @@ def build_queue(
             iou_thresh=iou_thresh,
             review_conf_thresh=review_conf_thresh,
             view=view,
+            containment_thresh=containment_thresh,
         )
         if kind is None:
             continue

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/app.js
@@ -1,7 +1,7 @@
 const state = {
   model: null, split: null,
   view: 'fp',
-  conf: 0.05, iou: 0.05, reviewConf: 0.35,
+  conf: 0.05, iou: 0.05, reviewConf: 0.35, contain: 0.7,
   showOrig: true, showPred: true, showOnlyVerified: false,
   showAnnotated: localStorage.getItem('show_annotated') === '1',
   reviewer: localStorage.getItem('reviewer') || '',
@@ -33,10 +33,10 @@ function filterQueueForView(items, showAnnotated) {
 
 const api = {
   contexts: () => fetch('/api/contexts').then(r => r.json()),
-  queue: ({ model, split, view, conf, iou, reviewConf }) =>
-    fetch(`/api/queue?model=${encodeURIComponent(model)}&split=${encodeURIComponent(split)}&view=${view}&conf=${conf}&iou=${iou}&review_conf=${reviewConf}`).then(r => r.json()),
-  sample: ({ model, split, stem, conf, iou, reviewConf }) =>
-    fetch(`/api/sample?model=${encodeURIComponent(model)}&split=${encodeURIComponent(split)}&stem=${encodeURIComponent(stem)}&conf=${conf}&iou=${iou}&review_conf=${reviewConf}`).then(r => r.json()),
+  queue: ({ model, split, view, conf, iou, reviewConf, contain }) =>
+    fetch(`/api/queue?model=${encodeURIComponent(model)}&split=${encodeURIComponent(split)}&view=${view}&conf=${conf}&iou=${iou}&review_conf=${reviewConf}&containment=${contain}`).then(r => r.json()),
+  sample: ({ model, split, stem, conf, iou, reviewConf, contain }) =>
+    fetch(`/api/sample?model=${encodeURIComponent(model)}&split=${encodeURIComponent(split)}&stem=${encodeURIComponent(stem)}&conf=${conf}&iou=${iou}&review_conf=${reviewConf}&containment=${contain}`).then(r => r.json()),
   save: ({ model, split, body }) =>
     fetch(`/api/sample?model=${encodeURIComponent(model)}&split=${encodeURIComponent(split)}`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -131,7 +131,7 @@ async function init() {
   selModel.addEventListener('change', () => { state.model = selModel.value; reloadQueue(); });
   selSplit.addEventListener('change', () => { state.split = selSplit.value; reloadQueue(); });
 
-  ['conf', 'iou', 'review-conf'].forEach(id => {
+  ['conf', 'iou', 'review-conf', 'contain'].forEach(id => {
     const el = document.getElementById(id);
     const valEl = document.getElementById(`${id}-v`);
     el.addEventListener('input', () => {
@@ -139,7 +139,8 @@ async function init() {
       valEl.textContent = v.toFixed(2);
       if (id === 'conf') state.conf = v;
       else if (id === 'iou') state.iou = v;
-      else state.reviewConf = v;
+      else if (id === 'review-conf') state.reviewConf = v;
+      else state.contain = v;
       debounceReload();
     });
   });
@@ -150,12 +151,15 @@ async function init() {
     state.conf = 0.05;
     state.iou = 0.05;
     state.reviewConf = 0.35;
+    state.contain = 0.7;
     document.getElementById('conf').value = '0.05';
     document.getElementById('iou').value = '0.05';
     document.getElementById('review-conf').value = '0.35';
+    document.getElementById('contain').value = '0.7';
     document.getElementById('conf-v').textContent = '0.05';
     document.getElementById('iou-v').textContent = '0.05';
     document.getElementById('review-conf-v').textContent = '0.35';
+    document.getElementById('contain-v').textContent = '0.70';
     reloadQueue();
   });
   document.querySelectorAll('#view-chips button').forEach(btn => {
@@ -257,6 +261,7 @@ async function reloadQueue() {
   const r = await api.queue({
     model: state.model, split: state.split, view: state.view,
     conf: state.conf, iou: state.iou, reviewConf: state.reviewConf,
+    contain: state.contain,
   });
   state.queueRaw = r.items;
   applyQueueFilter();
@@ -362,6 +367,7 @@ async function loadSample(stem, opts = {}) {
   state.sample = await api.sample({
     model: state.model, split: state.split, stem,
     conf: state.conf, iou: state.iou, reviewConf: state.reviewConf,
+    contain: state.contain,
   });
   state.queueIndex = state.queue.findIndex(q => q.stem === stem);
   state.dirty = false;

--- a/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
+++ b/experiments/data-quality/frame-level/src/data_quality_frame_level/audit_app/static/index.html
@@ -191,6 +191,11 @@
             <input type="range" id="review-conf" min="0" max="1" step="0.01" value="0.35">
             <span class="val" id="review-conf-v">0.35</span>
           </div>
+          <div class="slider-row">
+            <span class="hint" title="Containment threshold for the matcher. A prediction also counts as TP when at least this fraction of its area sits inside a GT box — independent of IoU. Slider at 0 = off (pure IoU).">contain ≥</span>
+            <input type="range" id="contain" min="0" max="1" step="0.05" value="0.7">
+            <span class="val" id="contain-v">0.70</span>
+          </div>
           <button id="filter-reset" type="button" class="mt-2 w-full rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-500 transition hover:border-sky-300 hover:bg-sky-50 hover:text-sky-700">Reset to defaults</button>
         </div>
       </section>

--- a/experiments/data-quality/frame-level/tests/test_audit_app_main.py
+++ b/experiments/data-quality/frame-level/tests/test_audit_app_main.py
@@ -304,3 +304,65 @@ def test_post_export_writes_manifest(tmp_path):
     assert (out / "manifest.json").is_file()
     prov = json.loads((out / "provenance.json").read_text())
     assert prov["thresholds"] == {"conf": 0.05, "iou": 0.05, "review_conf": 0.35}
+
+
+def test_get_queue_containment_default_absorbs_tight_pred(tmp_path: Path):
+    """Default containment (no param sent) absorbs a tight-pred-in-loose-GT case."""
+    split = tmp_path / "01_raw" / "datasets" / "val"
+    (split / "images").mkdir(parents=True)
+    (split / "labels").mkdir(parents=True)
+    stem = "s_2024-01-01T00-00-00"
+    (split / "images" / f"{stem}.jpg").write_bytes(b"jpeg")
+    (split / "labels" / f"{stem}.txt").write_text("0 0.5 0.5 0.4 0.4\n")
+    pred_path = tmp_path / "07_model_output" / "m" / "val" / "predictions.json"
+    pred_path.parent.mkdir(parents=True)
+    pred_path.write_text(
+        json.dumps(
+            {
+                "model_name": "m",
+                "split_dir": "data/01_raw/datasets/val",
+                "conf_thresh": 0.05,
+                "frames": {
+                    stem: {
+                        "image_path": f"images/{stem}.jpg",
+                        "predictions": [
+                            {
+                                "class_id": 0,
+                                "cx": 0.5,
+                                "cy": 0.5,
+                                "w": 0.05,
+                                "h": 0.05,
+                                "conf": 0.9,
+                            }
+                        ],
+                    },
+                },
+            }
+        )
+    )
+    paths = Paths(
+        split_dir=split,
+        predictions_path=pred_path,
+        review_path=tmp_path / "09_review" / "m" / "val" / "review.json",
+    )
+    app = create_app(
+        contexts={("m", "val"): paths},
+        models=["m"],
+        splits=["val"],
+        repo_root=tmp_path,
+    )
+    client = TestClient(app)
+    common = {
+        "model": "m",
+        "split": "val",
+        "view": "fp",
+        "conf": 0.05,
+        "iou": 0.5,
+        "review_conf": 0.5,
+    }
+    default = client.get("/api/queue", params=common).json()["items"]
+    off = client.get("/api/queue", params={**common, "containment": 0}).json()["items"]
+    flagged = [i for i in default if i["kind"] != "none"]
+    flagged_off = [i for i in off if i["kind"] != "none"]
+    assert flagged == []
+    assert [i["stem"] for i in flagged_off] == [stem]

--- a/experiments/data-quality/frame-level/tests/test_audit_app_matching.py
+++ b/experiments/data-quality/frame-level/tests/test_audit_app_matching.py
@@ -3,6 +3,7 @@ import pytest
 from data_quality_frame_level.audit_app.matching import (
     EvaluatedFrame,
     evaluate_frame,
+    iop,
     iou,
 )
 from data_quality_frame_level.audit_app.types import Prediction
@@ -47,3 +48,72 @@ def test_evaluate_frame_iou_threshold_filters():
     lenient = evaluate_frame(gt=gt, predictions=preds, iou_thresh=0.05)
     assert strict.gt_status == ["fn"] and strict.pred_status == ["fp"]
     assert lenient.gt_status == ["tp"] and lenient.pred_status == ["tp"]
+
+
+def test_iop_pred_fully_inside_gt():
+    gt = _gt(0.5, 0.5, 0.4, 0.4)
+    pred = _pred(0.5, 0.5, 0.1, 0.1, 0.9)
+    assert iop(pred, gt) == pytest.approx(1.0)
+
+
+def test_iop_pred_half_outside_gt():
+    gt = _gt(0.5, 0.5, 0.2, 0.2)
+    pred = _pred(0.6, 0.5, 0.2, 0.2, 0.9)
+    assert iop(pred, gt) == pytest.approx(0.5)
+
+
+def test_iop_pred_disjoint_from_gt():
+    gt = _gt(0.1, 0.1, 0.1, 0.1)
+    pred = _pred(0.9, 0.9, 0.1, 0.1, 0.9)
+    assert iop(pred, gt) == 0.0
+
+
+def test_evaluate_frame_duplicate_preds_all_tp():
+    """Many-to-one: 3 overlapping preds on one GT are all TP, no FP."""
+    gt = [_gt(0.5, 0.5, 0.2, 0.2)]
+    preds = [
+        _pred(0.50, 0.50, 0.2, 0.2, 0.9),
+        _pred(0.48, 0.50, 0.18, 0.18, 0.8),
+        _pred(0.52, 0.50, 0.18, 0.18, 0.7),
+    ]
+    out = evaluate_frame(gt=gt, predictions=preds, iou_thresh=0.5)
+    assert out.gt_status == ["tp"]
+    assert out.pred_status == ["tp", "tp", "tp"]
+
+
+def test_evaluate_frame_containment_absorbs_tight_pred():
+    """Tight pred inside generous GT: low IoU, high IoP -> TP only with containment."""
+    gt = [_gt(0.5, 0.5, 0.4, 0.4)]
+    preds = [_pred(0.5, 0.5, 0.1, 0.1, 0.9)]
+    no_contain = evaluate_frame(gt=gt, predictions=preds, iou_thresh=0.5)
+    with_contain = evaluate_frame(
+        gt=gt, predictions=preds, iou_thresh=0.5, containment_thresh=0.7,
+    )
+    assert no_contain.gt_status == ["fn"] and no_contain.pred_status == ["fp"]
+    assert with_contain.gt_status == ["tp"] and with_contain.pred_status == ["tp"]
+
+
+def test_evaluate_frame_giant_pred_over_two_gts_is_fp():
+    """Huge pred covering two adjacent GTs: low IoU + low IoP -> FP + FN + FN."""
+    gt = [_gt(0.30, 0.5, 0.05, 0.05), _gt(0.70, 0.5, 0.05, 0.05)]
+    preds = [_pred(0.5, 0.5, 0.9, 0.9, 0.9)]
+    out = evaluate_frame(
+        gt=gt, predictions=preds, iou_thresh=0.5, containment_thresh=0.7,
+    )
+    assert out.gt_status == ["fn", "fn"]
+    assert out.pred_status == ["fp"]
+
+
+def test_evaluate_frame_containment_none_is_pure_iou_many_to_one():
+    """containment_thresh=None: duplicates still TP (many-to-one), tight pred still FP."""
+    gt = [_gt(0.5, 0.5, 0.2, 0.2)]
+    duplicates = [
+        _pred(0.50, 0.50, 0.2, 0.2, 0.9),
+        _pred(0.48, 0.50, 0.18, 0.18, 0.8),
+    ]
+    tight = [_pred(0.5, 0.5, 0.05, 0.05, 0.9)]
+    out_dups = evaluate_frame(gt=gt, predictions=duplicates, iou_thresh=0.5)
+    out_tight = evaluate_frame(gt=gt, predictions=tight, iou_thresh=0.5)
+    assert out_dups.pred_status == ["tp", "tp"]
+    assert out_tight.gt_status == ["fn"]
+    assert out_tight.pred_status == ["fp"]

--- a/experiments/data-quality/frame-level/tests/test_audit_app_matching.py
+++ b/experiments/data-quality/frame-level/tests/test_audit_app_matching.py
@@ -87,7 +87,10 @@ def test_evaluate_frame_containment_absorbs_tight_pred():
     preds = [_pred(0.5, 0.5, 0.1, 0.1, 0.9)]
     no_contain = evaluate_frame(gt=gt, predictions=preds, iou_thresh=0.5)
     with_contain = evaluate_frame(
-        gt=gt, predictions=preds, iou_thresh=0.5, containment_thresh=0.7,
+        gt=gt,
+        predictions=preds,
+        iou_thresh=0.5,
+        containment_thresh=0.7,
     )
     assert no_contain.gt_status == ["fn"] and no_contain.pred_status == ["fp"]
     assert with_contain.gt_status == ["tp"] and with_contain.pred_status == ["tp"]
@@ -98,14 +101,17 @@ def test_evaluate_frame_giant_pred_over_two_gts_is_fp():
     gt = [_gt(0.30, 0.5, 0.05, 0.05), _gt(0.70, 0.5, 0.05, 0.05)]
     preds = [_pred(0.5, 0.5, 0.9, 0.9, 0.9)]
     out = evaluate_frame(
-        gt=gt, predictions=preds, iou_thresh=0.5, containment_thresh=0.7,
+        gt=gt,
+        predictions=preds,
+        iou_thresh=0.5,
+        containment_thresh=0.7,
     )
     assert out.gt_status == ["fn", "fn"]
     assert out.pred_status == ["fp"]
 
 
 def test_evaluate_frame_containment_none_is_pure_iou_many_to_one():
-    """containment_thresh=None: duplicates still TP (many-to-one), tight pred still FP."""
+    """containment_thresh=None: duplicates TP (many-to-one), tight pred still FP."""
     gt = [_gt(0.5, 0.5, 0.2, 0.2)]
     duplicates = [
         _pred(0.50, 0.50, 0.2, 0.2, 0.9),

--- a/experiments/data-quality/frame-level/tests/test_audit_app_queue.py
+++ b/experiments/data-quality/frame-level/tests/test_audit_app_queue.py
@@ -82,3 +82,25 @@ def test_fn_queue_sorts_by_max_gt_area():
         "seqB_2024-01-01T00-00-00",
         "seqA_2024-01-01T00-00-00",
     ]
+
+
+def test_fp_queue_absorbs_tight_pred_with_containment():
+    """A tight pred inside a generous GT is absorbed by default containment=0.7."""
+    stem = "s_2024-01-01T00-00-00"
+    predictions = {stem: [_pred(0.9, cx=0.5, cy=0.5, w=0.1, h=0.1)]}
+    gt = {stem: [_gt(cx=0.5, cy=0.5, w=0.4, h=0.4)]}
+    seq_map = _seq_map(predictions.keys() | gt.keys())
+    common_kwargs = dict(
+        predictions=predictions,
+        gt=gt,
+        sequence_id_by_stem=seq_map,
+        review_status={},
+        view="fp",
+        conf_thresh=0.05,
+        iou_thresh=0.5,
+        review_conf_thresh=0.5,
+    )
+    default = build_queue(**common_kwargs)
+    off = build_queue(**common_kwargs, containment_thresh=None)
+    assert default == []
+    assert [i.stem for i in off] == [stem]


### PR DESCRIPTION
## Summary

- Replaces the greedy 1-to-1 IoU matcher in the audit app with a many-to-one matcher that also accepts containment (IoP) as evidence of agreement. Default `containment_thresh = 0.7`.
- Stops surfacing frames whose only FPs are duplicate boxes or tight predictions sitting inside a generous GT — the dominant noise pattern in the train-split FP queue.
- Exposes a fourth slider (`contain ≥`) in the audit UI; slider at `0` falls back to pure-IoU many-to-one matching.

## Why

Greedy 1-to-1 IoU matching forces overlapping predictions on a single real plume into FPs (only one can claim the GT). Combined with loose smoke labels, the train FP queue is dominated by frames where the model is actually right.

## What changes

- `audit_app/matching.py` — new `iop()` helper, `evaluate_frame` rewritten to be many-to-one with optional `containment_thresh`. Composite predicate: `IoU >= iou_thresh OR (containment_thresh is not None AND IoP >= containment_thresh)`.
- `audit_app/queue.py` — threads `containment_thresh` through `build_queue` / `_frame_severity`, default `0.7`.
- `audit_app/main.py` — `containment: float = 0.7` on `GET /api/queue` and `GET /api/sample`. Server treats `containment == 0` as the off sentinel.
- `audit_app/static/{index.html,app.js}` — new slider, state field, listener, reset, query-string plumbing.
- Unit tests in `tests/test_audit_app_matching.py`, `tests/test_audit_app_queue.py`, `tests/test_audit_app_main.py` (8 new, 70 total green).

Persisted review state (`review.json`) and exports (`data/10_export/`) are untouched — the matcher is not in those code paths.

## Spec

`experiments/data-quality/frame-level/docs/specs/2026-05-15-audit-app-containment-matching-design.md`

## Test plan

- [x] `uv run pytest tests/` — 70 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] Manual UI: slider renders, FP queue shrinks on val with default 0.7, queue grows at slider 0, FN view unaffected, reset restores 0.70, reviewed frames unaffected