### PR TITLE
data(explorer): track 332 pyro-annotator sequences (DVC)

### DIFF
--- a/experiments/temporal-models/temporal-model-explorer/data/03_primary/sequences/pyro-annotator.dvc
+++ b/experiments/temporal-models/temporal-model-explorer/data/03_primary/sequences/pyro-annotator.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: b1ff41224c407344f0a57ec8ca5663e1.dir
+  size: 575544716
+  nfiles: 5083
+  hash: md5
+  path: pyro-annotator


### PR DESCRIPTION
## Summary
- Full import of the pyro-annotator zip export into the store, enriched via the admin platform API (camera/org/timestamps).
- **332 sequences**, all resolved to `sdis-77` across 8 cameras. Labels: fp 273 / smoke 44 / unknown 15.
- `dvc add`-ed as `data/03_primary/sequences/pyro-annotator.dvc` (575 MB, 5083 files).

## Notes
- Enrichment success: **332/332**, zero failures, zero `unknown` fallbacks. 291 sequences got per-frame timestamps; 41 are curated subsets (only `started_at`).
- ⚠️ **Data not yet pushed to S3** — run `dvc push` before merging so teammates can `dvc pull`.

## Test Plan
- [ ] `dvc push` the data
- [ ] `dvc repro run_models` to score the new sequences, then verify they appear under the `pyro-annotator` source in the app