### PR TITLE
feat(explorer): source label/order + editable lib deps

### DIFF
--- a/experiments/temporal-models/temporal-model-explorer/dvc.lock
+++ b/experiments/temporal-models/temporal-model-explorer/dvc.lock
@@ -15,8 +15,8 @@ stages:
     outs:
     - path: data/06_models
       hash: md5
-      md5: 59dac007dd00a31de5f93d4e8d394d4b.dir
-      size: 162765093
+      md5: 44f0178915718f4a509b58ec8eeabb2d.dir
+      size: 162765157
       nfiles: 1
   run_models:
     cmd: uv run python scripts/run_models.py --store data/03_primary/sequences 
@@ -24,13 +24,13 @@ stages:
     deps:
     - path: data/03_primary/sequences
       hash: md5
-      md5: 84dcf42265e29d51d7dba5931131e186.dir
-      size: 1087779014
-      nfiles: 8928
+      md5: 60cadabcb8d4df06c90e5229516723eb.dir
+      size: 1663323730
+      nfiles: 14011
     - path: data/06_models
       hash: md5
-      md5: 59dac007dd00a31de5f93d4e8d394d4b.dir
-      size: 162765093
+      md5: 44f0178915718f4a509b58ec8eeabb2d.dir
+      size: 162765157
       nfiles: 1
     - path: scripts/run_models.py
       hash: md5
@@ -46,15 +46,15 @@ stages:
       size: 3577
     - path: src/temporal_model_explorer/store.py
       hash: md5
-      md5: 0dff1059fea663891fdc74effb0902ee
-      size: 2771
+      md5: bdbaeab60b63094d3e942d4fb4157dac
+      size: 2946
     outs:
     - path: data/07_model_output/details
       hash: md5
-      md5: e3450c2d21cd4c56ddcc2cbd44d15fd6.dir
-      size: 3974263
-      nfiles: 698
+      md5: 81fa9843db58c7e86fa3aae426d313b2.dir
+      size: 6101751
+      nfiles: 1030
     - path: data/07_model_output/results.parquet
       hash: md5
-      md5: 0511584db6b724a1e58ca2d2d1c39c13
-      size: 35165
+      md5: 2176cc1b970c0a69e4e57c5576b72d1a
+      size: 49314

--- a/experiments/temporal-models/temporal-model-explorer/pyproject.toml
+++ b/experiments/temporal-models/temporal-model-explorer/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-bbox-tube-temporal-core = { path = "../../../lib/bbox-tube-temporal" }
-pyrocore = { path = "../../../lib/pyrocore" }
+bbox-tube-temporal-core = { path = "../../../lib/bbox-tube-temporal", editable = true }
+pyrocore = { path = "../../../lib/pyrocore", editable = true }
 
 [dependency-groups]
 dev = ["pytest>=8.0", "ruff>=0.9", "dvc[s3]>=3.56"]

--- a/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
+++ b/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
@@ -47,6 +47,7 @@ except TypeError:  # older Pillow without the size kwarg
 
 # Display vocabulary. The underlying columns stay label/decision/outcome; the UI
 # shows: ground truth (label) · model verdict (decision) · correctness (outcome).
+SOURCE_DISPLAY = {"platform": "alert-api"}  # stored source value -> sidebar label
 CORRECTNESS = {
     "kept-smoke": "✅ smoke kept",
     "discarded-fp": "✅ fp filtered",
@@ -513,8 +514,21 @@ def main() -> None:  # pragma: no cover - Streamlit UI
     )
 
     st.sidebar.header("Select")
-    sources = sorted(x for x in df["source"].dropna().unique())
-    source = st.sidebar.selectbox("source", sources, key="source") if sources else None
+    # pyro-annotator first (default), then any other source alphabetically.
+    sources = sorted(
+        (x for x in df["source"].dropna().unique()),
+        key=lambda s: (s != "pyro-annotator", s),
+    )
+    source = (
+        st.sidebar.selectbox(
+            "source",
+            sources,
+            format_func=lambda s: SOURCE_DISPLAY.get(s, s),
+            key="source",
+        )
+        if sources
+        else None
+    )
     src_df = df[df["source"] == source] if source else df
     orgs = sorted(x for x in src_df["organization_name"].dropna().unique())
     org = st.sidebar.selectbox("organization", orgs, key="org") if orgs else None

--- a/experiments/temporal-models/temporal-model-explorer/uv.lock
+++ b/experiments/temporal-models/temporal-model-explorer/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 [[package]]
 name = "bbox-tube-temporal-core"
 version = "0.1.0"
-source = { directory = "../../../lib/bbox-tube-temporal" }
+source = { editable = "../../../lib/bbox-tube-temporal" }
 dependencies = [
     { name = "numpy" },
     { name = "pillow" },
@@ -3043,7 +3043,7 @@ wheels = [
 [[package]]
 name = "pyrocore"
 version = "0.1.0"
-source = { directory = "../../../lib/pyrocore" }
+source = { editable = "../../../lib/pyrocore" }
 
 [package.metadata]
 requires-dist = [
@@ -3665,11 +3665,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bbox-tube-temporal-core", directory = "../../../lib/bbox-tube-temporal" },
+    { name = "bbox-tube-temporal-core", editable = "../../../lib/bbox-tube-temporal" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "pyarrow", specifier = ">=15" },
-    { name = "pyrocore", directory = "../../../lib/pyrocore" },
+    { name = "pyrocore", editable = "../../../lib/pyrocore" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "streamlit", specifier = ">=1.40" },


### PR DESCRIPTION
## Summary
Follow-ups to the source selector (PR #75), plus a build fix:
- **`alert-api` label**: render the stored source value `platform` as `alert-api` in the sidebar (display-only via `format_func`; stored data unchanged).
- **Default source**: order `pyro-annotator` first so it's the default selection.
- **Editable lib deps**: `bbox-tube-temporal-core` and `pyrocore` are now `editable = true` path deps. Previously they were non-editable and pinned at `0.1.0`, so lib source changes silently failed to reach the venv until a version bump + reinstall — which caused the explorer to run pre-merge tube-building code (no `merge_colocated_tubes`) despite the lib having it. Editable installs make lib changes live.

## Test Plan
- [x] `ruff format` + `ruff check` clean
- [x] 46 tests pass
- [x] Verified imports resolve to `lib/.../src` (editable) and selector shows `[pyro-annotator, alert-api]`