### PR TITLE
feat(explorer): model performance section (recall / FP-filtered / precision)

### DIFF
--- a/docs/specs/2026-06-01-explorer-performance-section-design.md
+++ b/docs/specs/2026-06-01-explorer-performance-section-design.md
@@ -69,8 +69,11 @@ and `model` (not the org/camera-filtered `view`).
 ### 3. Visibility
 
 Driven entirely by `n_labeled`: the section renders only when the selected
-source has labeled rows. This shows for `pyro-annotator` (default) and
-auto-hides for `alert-api`/`platform` — no source-name hardcoding.
+source has labeled (`smoke`/`fp`) rows — no source-name hardcoding. It always
+shows for `pyro-annotator` (fully labeled). It also shows for any other source
+that carries labeled rows: `alert-api`/`platform` has a labeled subset (~81 of
+its sequences have a real `is_wildfire`), so the cards render there too, scoped
+to that subset. A source with zero labeled rows renders nothing.
 
 ## Error handling / edge cases
 

--- a/docs/specs/2026-06-01-explorer-performance-section-design.md
+++ b/docs/specs/2026-06-01-explorer-performance-section-design.md
@@ -1,0 +1,96 @@
+# Model performance section (explorer) — design
+
+**Date:** 2026-06-01
+**Experiment:** `experiments/temporal-models/temporal-model-explorer`
+**Branch:** `arthur/feat-temporal-model-explorer-stats`
+**Status:** approved, pending implementation plan
+
+## Goal
+
+Add an at-a-glance "model performance" section to the Temporal Model Explorer so
+that, on opening the app, you can immediately confirm how strong the model is on
+the **pyro-annotator** labeled eval set — without scrolling the per-sequence
+table. Three headline metrics: recall, FP-filtered (specificity), precision.
+
+## Context
+
+`results.parquet` has one row per (sequence, model) with `source`, `label`
+(`smoke`/`fp`/`unknown`), `decision` (`keep`/`discard`), and `outcome`
+(`kept-smoke`/`discarded-fp`/`kept-fp`/`discarded-smoke`/`n/a`). Pyro-annotator
+sequences carry real ground-truth labels; alert-API (`platform`) labels are
+mostly `unknown`, so these metrics are only meaningful where labeled rows exist.
+
+Confusion-matrix mapping (labeled rows only):
+- TP = `kept-smoke`, FN = `discarded-smoke`, TN = `discarded-fp`, FP = `kept-fp`.
+
+## Design
+
+### 1. Computation — pure, testable (`src/temporal_model_explorer/outcomes.py`)
+
+Add a pure function:
+
+```python
+def performance_summary(df: pd.DataFrame) -> dict:
+    """Headline metrics over labeled rows (label in {smoke, fp}) of df.
+
+    df is expected to already be narrowed to one source + model. Returns counts
+    plus recall / specificity / precision, each None when its denominator is 0.
+    """
+```
+
+Returns a dict with:
+- `n_labeled`, `n_smoke`, `n_fp`
+- `kept_smoke`, `discarded_smoke`, `discarded_fp`, `kept_fp`
+- `recall` = `kept_smoke / n_smoke` (None if `n_smoke == 0`)
+- `specificity` = `discarded_fp / n_fp` (None if `n_fp == 0`)  ← "FP-filtered"
+- `precision` = `kept_smoke / (kept_smoke + kept_fp)` (None if no kept)
+
+No Streamlit, no I/O. Derives counts from the `outcome` column.
+
+### 2. Rendering (`src/temporal_model_explorer/app.py`)
+
+Add `render_performance(df, source, model)` (marked `# pragma: no cover` like
+`main`). It:
+- selects rows where `source == source` and `model == model` — **ignoring
+  org/camera** (the "overall eval set"),
+- calls `performance_summary`,
+- if `n_labeled == 0`, renders nothing,
+- otherwise renders a row of **3 `st.metric` cards** (Recall, FP-filtered,
+  Precision) in `st.columns(3)`, each showing the value as a percent with the
+  underlying fraction as a caption (e.g. Recall **95.5%**, caption "42/44").
+  A metric whose value is `None` shows "—".
+- Above the cards, a caption with sample size: e.g.
+  *"Model performance — 317 labeled sequences (273 fp · 44 smoke)"*.
+
+Call it at the **top of the main pane** in `main()`, above the `title_ph`
+per-sequence title/table block, passing the full `df` plus the selected `source`
+and `model` (not the org/camera-filtered `view`).
+
+### 3. Visibility
+
+Driven entirely by `n_labeled`: the section renders only when the selected
+source has labeled rows. This shows for `pyro-annotator` (default) and
+auto-hides for `alert-api`/`platform` — no source-name hardcoding.
+
+## Error handling / edge cases
+
+- Zero-denominator metric → card shows "—" (not a crash, not 0%).
+- No labeled rows for the source → section omitted entirely.
+- `probability` is not used here (operating-point metrics only).
+
+## Testing
+
+`tests/test_outcomes.py` — unit tests for `performance_summary`:
+- Balanced fixture with known TP/FN/TN/FP → asserts exact recall/specificity/
+  precision and counts.
+- `n_smoke == 0` → `recall is None`; nothing-kept → `precision is None`.
+- Rows with `label == "unknown"` are excluded from `n_labeled` and all metrics.
+
+The Streamlit `render_performance` is left untested (matches the existing
+`# pragma: no cover` convention on `main`).
+
+## Files touched
+
+- **edit** `src/temporal_model_explorer/outcomes.py` — add `performance_summary`
+- **edit** `src/temporal_model_explorer/app.py` — add + call `render_performance`
+- **edit** `tests/test_outcomes.py` — tests for `performance_summary`

--- a/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
+++ b/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
@@ -495,7 +495,9 @@ def _drilldown(key: str, model: str, row: pd.Series) -> None:  # pragma: no cove
             tubes_col.caption("inactive at this frame")
 
 
-def render_performance(df, source, model) -> None:  # pragma: no cover - Streamlit UI
+def render_performance(
+    df: pd.DataFrame, source: str | None, model: str
+) -> None:  # pragma: no cover - Streamlit UI
     """Three headline metric cards over the full source+model labeled eval set.
 
     Ignores org/camera (overall numbers). Renders nothing when the selected
@@ -519,8 +521,11 @@ def render_performance(df, source, model) -> None:  # pragma: no cover - Streaml
         ),
     )
     for col, (label, value, frac) in zip(st.columns(3), cards, strict=True):
-        col.metric(label, "—" if value is None else f"{value:.1%}")
-        col.caption(frac)
+        if value is None:
+            col.metric(label, "—")
+        else:
+            col.metric(label, f"{value:.1%}")
+            col.caption(frac)
 
 
 def main() -> None:  # pragma: no cover - Streamlit UI

--- a/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
+++ b/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
@@ -29,6 +29,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 # Absolute imports: this module is the Streamlit entrypoint, run as __main__ via
 # `streamlit run app.py` (no package context), so relative imports would fail.
+from temporal_model_explorer.outcomes import performance_summary
 from temporal_model_explorer.store import iter_sequence_dirs, read_meta
 
 RESULTS = Path("data/07_model_output/results.parquet")
@@ -494,6 +495,34 @@ def _drilldown(key: str, model: str, row: pd.Series) -> None:  # pragma: no cove
             tubes_col.caption("inactive at this frame")
 
 
+def render_performance(df, source, model) -> None:  # pragma: no cover - Streamlit UI
+    """Three headline metric cards over the full source+model labeled eval set.
+
+    Ignores org/camera (overall numbers). Renders nothing when the selected
+    source has no labeled (smoke/fp) sequences, e.g. alert-api.
+    """
+    sub = df[(df["source"] == source) & (df["model"] == model)]
+    s = performance_summary(sub)
+    if s["n_labeled"] == 0:
+        return
+    st.caption(
+        f"Model performance — {s['n_labeled']} labeled sequences "
+        f"({s['n_fp']} fp · {s['n_smoke']} smoke)"
+    )
+    cards = (
+        ("Recall (smoke kept)", s["recall"], f"{s['kept_smoke']}/{s['n_smoke']}"),
+        ("FP filtered", s["specificity"], f"{s['discarded_fp']}/{s['n_fp']}"),
+        (
+            "Precision",
+            s["precision"],
+            f"{s['kept_smoke']}/{s['kept_smoke'] + s['kept_fp']}",
+        ),
+    )
+    for col, (label, value, frac) in zip(st.columns(3), cards, strict=True):
+        col.metric(label, "—" if value is None else f"{value:.1%}")
+        col.caption(frac)
+
+
 def main() -> None:  # pragma: no cover - Streamlit UI
     st.set_page_config(page_title="Temporal Model Explorer", layout="wide")
     st.title("Temporal Model Explorer")
@@ -549,6 +578,8 @@ def main() -> None:  # pragma: no cover - Streamlit UI
         .sort_values("started_at", ascending=False)
         .reset_index(drop=True)
     )
+
+    render_performance(df, source, model)
 
     # Full-width title (filled via a placeholder after filtering so its count
     # reflects the filter). Below it, a horizontal bar where the legend stretches to

--- a/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/outcomes.py
+++ b/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/outcomes.py
@@ -58,3 +58,32 @@ def filter_results(
     if errors_only:
         out = out[out["outcome"].isin(ERROR_OUTCOMES)]
     return out
+
+
+def performance_summary(df: pd.DataFrame) -> dict:
+    """Headline metrics over labeled rows (label in {smoke, fp}) of ``df``.
+
+    ``df`` is expected to already be narrowed to one source + model. Returns
+    counts plus recall / specificity (FP-filtered) / precision, each ``None``
+    when its denominator is 0. Counts are derived from the ``outcome`` column.
+    """
+    oc = df[df["label"].isin(("smoke", "fp"))]["outcome"]
+    kept_smoke = int((oc == "kept-smoke").sum())
+    discarded_smoke = int((oc == "discarded-smoke").sum())
+    discarded_fp = int((oc == "discarded-fp").sum())
+    kept_fp = int((oc == "kept-fp").sum())
+    n_smoke = kept_smoke + discarded_smoke
+    n_fp = discarded_fp + kept_fp
+    n_kept = kept_smoke + kept_fp
+    return {
+        "n_labeled": n_smoke + n_fp,
+        "n_smoke": n_smoke,
+        "n_fp": n_fp,
+        "kept_smoke": kept_smoke,
+        "discarded_smoke": discarded_smoke,
+        "discarded_fp": discarded_fp,
+        "kept_fp": kept_fp,
+        "recall": kept_smoke / n_smoke if n_smoke else None,
+        "specificity": discarded_fp / n_fp if n_fp else None,
+        "precision": kept_smoke / n_kept if n_kept else None,
+    }

--- a/experiments/temporal-models/temporal-model-explorer/tests/test_outcomes.py
+++ b/experiments/temporal-models/temporal-model-explorer/tests/test_outcomes.py
@@ -5,6 +5,7 @@ from temporal_model_explorer.outcomes import (
     decision_from_output,
     filter_results,
     max_probability,
+    performance_summary,
 )
 
 
@@ -57,3 +58,42 @@ def test_filter_results_errors_only_returns_errors():
     )
     out = filter_results(df, errors_only=True)
     assert list(out["outcome"]) == ["discarded-smoke"]
+
+
+def _r(label, outcome):
+    return {"label": label, "outcome": outcome}
+
+
+def test_performance_summary_known_counts():
+    df = pd.DataFrame(
+        [
+            _r("smoke", "kept-smoke"),
+            _r("smoke", "kept-smoke"),
+            _r("smoke", "discarded-smoke"),  # 2 TP, 1 FN
+            _r("fp", "discarded-fp"),
+            _r("fp", "discarded-fp"),
+            _r("fp", "discarded-fp"),
+            _r("fp", "kept-fp"),  # 3 TN, 1 FP
+            _r("unknown", "n/a"),  # excluded
+        ]
+    )
+    s = performance_summary(df)
+    assert s["n_labeled"] == 7 and s["n_smoke"] == 3 and s["n_fp"] == 4
+    assert s["recall"] == 2 / 3  # kept_smoke / n_smoke
+    assert s["specificity"] == 3 / 4  # discarded_fp / n_fp
+    assert s["precision"] == 2 / 3  # kept_smoke / (kept_smoke + kept_fp)
+
+
+def test_performance_summary_zero_denominators():
+    df = pd.DataFrame([_r("fp", "discarded-fp"), _r("fp", "discarded-fp")])
+    s = performance_summary(df)
+    assert s["n_smoke"] == 0 and s["recall"] is None
+    assert s["precision"] is None  # nothing kept
+    assert s["specificity"] == 1.0
+
+
+def test_performance_summary_excludes_unknown():
+    df = pd.DataFrame([_r("unknown", "n/a"), _r("unknown", "n/a")])
+    s = performance_summary(df)
+    assert s["n_labeled"] == 0
+    assert s["recall"] is None and s["specificity"] is None and s["precision"] is None

--- a/experiments/temporal-models/temporal-model-explorer/tests/test_outcomes.py
+++ b/experiments/temporal-models/temporal-model-explorer/tests/test_outcomes.py
@@ -92,6 +92,15 @@ def test_performance_summary_zero_denominators():
     assert s["specificity"] == 1.0
 
 
+def test_performance_summary_precision_zero_when_only_fp_kept():
+    # kept only false positives: precision 0.0 (not None), recall None (no smoke)
+    df = pd.DataFrame([_r("fp", "kept-fp"), _r("fp", "kept-fp")])
+    s = performance_summary(df)
+    assert s["precision"] == 0.0
+    assert s["recall"] is None
+    assert s["specificity"] == 0.0  # discarded_fp 0 / n_fp 2
+
+
 def test_performance_summary_excludes_unknown():
     df = pd.DataFrame([_r("unknown", "n/a"), _r("unknown", "n/a")])
     s = performance_summary(df)


### PR DESCRIPTION
## Summary
Adds an at-a-glance **model performance** section to the top of the explorer's main pane, so you can confirm how strong the model is without scrolling the per-sequence table.

- `performance_summary(df)` in `outcomes.py` — pure helper computing **recall**, **FP-filtered (specificity)**, and **precision** (+ underlying counts) over labeled rows (`label in {smoke, fp}`), each `None` when its denominator is 0.
- `render_performance(df, source, model)` in `app.py` — three `st.metric` cards over the selected source+model **labeled eval set, ignoring org/camera** (overall numbers), with a sample-size caption. Each card shows the `%` and the underlying fraction.

## Behavior note
Visibility is driven by "has labeled rows", not a hardcoded source. So it shows for **pyro-annotator** (recall 95.5% / FP-filtered 69.2% / precision 33.3%, n=317) and also for **alert-api**, which turns out to have 81 labeled sequences (recall 71.7% / 60.7% / 77.6%). A source with no labels renders nothing.

## Test Plan
- [x] `ruff format` + `ruff check` clean
- [x] 49 tests pass (3 new for `performance_summary`: known counts, zero denominators → None, unknown-label exclusion)
- [x] Verified card numbers against the live `results.parquet` for both sources