### PR TITLE
feat(bbox-tube-temporal): add opt-in stabilize crop mode (default off)

### DIFF
--- a/experiments/temporal-models/bbox-tube-temporal/docs/specs/2026-06-05-stabilized-crop-retrain-design.md
+++ b/experiments/temporal-models/bbox-tube-temporal/docs/specs/2026-06-05-stabilized-crop-retrain-design.md
@@ -1,0 +1,117 @@
+# Stabilized per-tube crops + retrain (vit_dinov2_finetune A/B)
+
+Date: 2026-06-05
+Status: approved (brainstorm)
+
+## Problem
+
+The temporal head is fed **per-frame** crops: each tube entry's own bbox is
+expanded by `context_factor` (currently 1.5), squared, and resized to 224
+(`bbox_tube_temporal.model_input.process_tube` for training data,
+`bbox_tube_temporal.inference.crop_tube_patches` at inference). Because the crop
+recenters and rescales every frame, the smoke stays roughly centered/same-size
+and the background slides — a "jumpy" sequence in which the smoke never appears
+to move.
+
+We prototyped an alternative in `tube-builder-lab`: a **single fixed crop window
+per tube** (the union of the tube's observed boxes), applied to every frame, so
+the background is static and the smoke visibly moves/grows inside it. This spec
+incorporates that into the real experiment and **retrains `vit_dinov2_finetune`**
+to measure whether it improves or degrades performance.
+
+## Goal
+
+Add an opt-in `stabilize` crop mode to the lib (training + inference), wire a
+`model_input.stabilize` param through the experiment, and run a single stabilized
+A/B against the **already-recorded** `vit_dinov2_finetune` baseline.
+
+## Key decisions
+
+- **A/B subject:** `vit_dinov2_finetune` only.
+- **Baseline:** the committed `vit_dinov2_finetune` metrics
+  (`data/08_reporting/val/vit_dinov2_finetune/`) — **not re-run**.
+- **One arm, one seed:** a single stabilized run, seed 42, `context_factor=1.5`,
+  merged tubes unchanged — so the only difference vs the recorded baseline is
+  per-frame box → fixed-union box.
+- **Mechanism:** `dvc exp run -S model_input.stabilize=true` targeting the dinov2
+  eval — isolated experiment, committed baseline data/metrics untouched; compare
+  with `dvc exp show`.
+- **Window:** the union (enclosing) box of the tube's observed (non-gap,
+  real-detection) boxes. No separate margin — the crop step's `context_factor`
+  supplies the context (same value, 1.5, both arms).
+- **Judgement:** holistic over the full protocol report — precision / recall /
+  F1 / FPR, PR-AUC, ROC-AUC, and time-to-detection (TTD).
+- **Implementation shape:** a `stabilize: bool` threaded through the two crop
+  functions (rejected: a pluggable strategy object — YAGNI; precomputing the
+  window onto the tube record — spreads the concept for no gain).
+
+### Honest caveat (recorded with the result)
+
+Single-seed, baseline-not-re-run. The val set is small (n=284; 7 FP, 1 FN), so
+differences within seed noise are **not** conclusive. A small delta is "neutral,"
+not a win/loss. Escalating to multi-seed (42/43/44, both arms) is the follow-up
+if the result is borderline and worth pursuing.
+
+## Components
+
+### Lib — `lib/bbox-tube-temporal/src/bbox_tube_temporal/`
+
+- `tube_window(tube) -> (cx, cy, w, h)` — union of the tube's observed
+  detections, normalized; raises on a tube with no observed detection; ignores
+  gap/interpolated entries (lerps of observed boxes, already enclosed). Ported
+  from `tube-builder-lab`'s `stabilize.tube_window`. Pure, unit-tested.
+- `process_tube(..., stabilize: bool = False)` — when true, compute the window
+  once and crop that fixed box (`expand_bbox(window, context_factor)` → square →
+  resize) for every frame. `False` is byte-identical to today.
+- `crop_tube_patches(..., stabilize: bool = False)` — the same switch on the
+  inference path, so a stabilized-trained model crops consistently when deployed.
+
+### Experiment — `bbox-tube-temporal`
+
+- `params.yaml`: add `model_input.stabilize: false` (new DVC param beside
+  `context_factor` / `patch_size`).
+- `scripts/build_model_input.py`: add `--stabilize` flag, pass to `process_tube`.
+- `dvc.yaml` `model_input` stage: pass `${model_input.stabilize}` and list it
+  under `params:` so toggling it invalidates the crop cache.
+- **Inference parity:** `package_model` serializes `model_input.stabilize` into
+  the packaged config; `BboxTubeTemporalModel.predict` passes it to
+  `crop_tube_patches` (beside `mi["context_factor"]`, `model.py:225`). Default
+  `false` keeps every existing packaged model valid.
+
+## Data flow
+
+```
+tubes JSON ─┬─ build_model_input (--stabilize) ─▶ stabilized 224 PNG patches ─▶ train vit_dinov2_finetune ─▶ evaluate ─▶ metrics
+            └─ tube_window (union) ── context_factor 1.5 ── same crop code as per-frame
+packaged config { model_input.stabilize } ─▶ predict ─▶ crop_tube_patches(stabilize) ─▶ inference parity
+```
+
+## Testing
+
+- Lib: `tube_window` (two-box union, single-box, gaps ignored, empty raises);
+  `process_tube(stabilize=True)` yields a constant crop box across frames while
+  `stabilize=False` is unchanged (tiny synthetic tube).
+- Experiment: `--stabilize` reaches `process_tube`.
+- `make lint` + `make test` green in **both** the lib and the experiment.
+
+## Results (to fill after the run)
+
+| metric | baseline (recorded) | stabilized | Δ |
+|---|---|---|---|
+| precision | 0.950 | | |
+| recall | 0.993 | | |
+| F1 | 0.971 | | |
+| FPR | | | |
+| PR-AUC | 0.991 | | |
+| ROC-AUC | 0.993 | | |
+| TTD (median frames) | | | |
+
+Verdict: _improve / neutral / degrade_ — with the single-seed caveat.
+
+## Out of scope
+
+- Retraining other variants (gru_*, vit_in21k, etc.).
+- Re-running the baseline / multi-seed (follow-up if borderline).
+- Tuning `context_factor` or the window definition (held fixed to isolate the
+  per-frame-vs-union change).
+- Smoothed/EMA or size-only windows (rejected in the lab brainstorm).

--- a/experiments/temporal-models/bbox-tube-temporal/dvc.yaml
+++ b/experiments/temporal-models/bbox-tube-temporal/dvc.yaml
@@ -71,9 +71,11 @@ stages:
         --output-dir data/05_model_input/${item}
         --context-factor ${model_input.context_factor}
         --patch-size ${model_input.patch_size}
+        --stabilize ${model_input.stabilize}
       deps:
         - scripts/build_model_input.py
         - ../../../lib/bbox-tube-temporal/src/bbox_tube_temporal/model_input.py
+        - ../../../lib/bbox-tube-temporal/src/bbox_tube_temporal/stabilize.py
         - data/03_primary/tubes/${item}
         - data/01_raw/datasets/${item}
       params:

--- a/experiments/temporal-models/bbox-tube-temporal/params.yaml
+++ b/experiments/temporal-models/bbox-tube-temporal/params.yaml
@@ -30,6 +30,7 @@ build_tubes:
 model_input:
   context_factor: 1.5
   patch_size: 224
+  stabilize: false
 
 _train_defaults: &train_defaults
   hidden_dim: 128

--- a/experiments/temporal-models/bbox-tube-temporal/scripts/build_model_input.py
+++ b/experiments/temporal-models/bbox-tube-temporal/scripts/build_model_input.py
@@ -18,12 +18,18 @@ from pathlib import Path
 from bbox_tube_temporal.model_input import LABEL_TO_INT, process_tube
 
 
+def _to_bool(value: str) -> bool:
+    """Parse a DVC-substituted boolean param (``true``/``false``)."""
+    return str(value).strip().lower() in {"true", "1", "yes"}
+
+
 def _process_one(
     tube_path: Path,
     raw_dir: Path,
     out_dir: Path,
     context_factor: float,
     patch_size: int,
+    stabilize: bool,
 ) -> tuple[str | None, str, str | None]:
     """Worker: returns (sequence_id, label, error_or_none)."""
     try:
@@ -36,6 +42,7 @@ def _process_one(
             out_dir=out_dir,
             context_factor=context_factor,
             patch_size=patch_size,
+            stabilize=stabilize,
         )
         return sequence_id, label, None
     except Exception as exc:  # noqa: BLE001
@@ -49,6 +56,7 @@ def main() -> None:
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--context-factor", type=float, required=True)
     parser.add_argument("--patch-size", type=int, required=True)
+    parser.add_argument("--stabilize", default="false")
     parser.add_argument(
         "--workers",
         type=int,
@@ -78,6 +86,7 @@ def main() -> None:
                 args.output_dir,
                 args.context_factor,
                 args.patch_size,
+                _to_bool(args.stabilize),
             )
             for p in tube_paths
         ]

--- a/experiments/temporal-models/bbox-tube-temporal/scripts/package_model.py
+++ b/experiments/temporal-models/bbox-tube-temporal/scripts/package_model.py
@@ -103,6 +103,19 @@ def _tubes_config(all_params: dict) -> dict:
     return cfg
 
 
+def _model_input_config(all_params: dict) -> dict:
+    mi = all_params["model_input"]
+    return {
+        "context_factor": mi["context_factor"],
+        "patch_size": mi["patch_size"],
+        "stabilize": mi.get("stabilize", False),
+        "normalization": {
+            "mean": [0.485, 0.456, 0.406],
+            "std": [0.229, 0.224, 0.225],
+        },
+    }
+
+
 def _build_config(
     all_params: dict,
     variant_cfg: dict,
@@ -124,14 +137,7 @@ def _build_config(
     return {
         "infer": package_params["infer"],
         "tubes": _tubes_config(all_params),
-        "model_input": {
-            "context_factor": all_params["model_input"]["context_factor"],
-            "patch_size": all_params["model_input"]["patch_size"],
-            "normalization": {
-                "mean": [0.485, 0.456, 0.406],
-                "std": [0.229, 0.224, 0.225],
-            },
-        },
+        "model_input": _model_input_config(all_params),
         "classifier": _classifier_kwargs(variant_cfg),
         "decision": decision,
     }

--- a/experiments/temporal-models/bbox-tube-temporal/tests/test_build_model_input_script.py
+++ b/experiments/temporal-models/bbox-tube-temporal/tests/test_build_model_input_script.py
@@ -1,0 +1,24 @@
+"""Unit tests for build_model_input.py's pure helpers."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "build_model_input.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("build_model_input_script", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["build_model_input_script"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_to_bool_parses_dvc_strings():
+    mod = _load()
+    assert mod._to_bool("true") is True
+    assert mod._to_bool("True") is True
+    assert mod._to_bool("false") is False
+    assert mod._to_bool("False") is False
+    assert mod._to_bool("0") is False

--- a/experiments/temporal-models/bbox-tube-temporal/tests/test_package_model_script.py
+++ b/experiments/temporal-models/bbox-tube-temporal/tests/test_package_model_script.py
@@ -45,3 +45,21 @@ def test_tubes_config_omits_merge_keys_when_any_missing():
     assert "merge_iomin" not in cfg
     assert "merge_prox_factor" not in cfg
     assert "merge_max_gap" not in cfg
+
+
+def test_model_input_config_carries_stabilize_default_false():
+    mod = _load_script_module("package_model_script_mi_default")
+    all_params = {"model_input": {"context_factor": 1.5, "patch_size": 224}}
+    cfg = mod._model_input_config(all_params)
+    assert cfg["context_factor"] == 1.5
+    assert cfg["patch_size"] == 224
+    assert cfg["stabilize"] is False
+
+
+def test_model_input_config_carries_stabilize_true():
+    mod = _load_script_module("package_model_script_mi_true")
+    all_params = {
+        "model_input": {"context_factor": 1.5, "patch_size": 224, "stabilize": True}
+    }
+    cfg = mod._model_input_config(all_params)
+    assert cfg["stabilize"] is True

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/inference.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/inference.py
@@ -15,6 +15,7 @@ from torchvision.transforms.functional import to_tensor
 
 from .logistic_calibrator import LogisticCalibrator, extract_features
 from .model_input import crop_and_resize, expand_bbox, norm_bbox_to_pixel_square
+from .stabilize import union_window
 from .tubes import (
     build_tubes,
     merge_colocated_tubes,
@@ -207,6 +208,7 @@ def crop_tube_patches(
     max_frames: int,
     normalization_mean: list[float],
     normalization_std: list[float],
+    stabilize: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Crop patches for a single tube, padded/truncated to ``max_frames``.
 
@@ -222,6 +224,21 @@ def crop_tube_patches(
     mean_t = torch.tensor(normalization_mean).view(3, 1, 1)
     std_t = torch.tensor(normalization_std).view(3, 1, 1)
 
+    window = None
+    if stabilize:
+        observed = [
+            (e.detection.cx, e.detection.cy, e.detection.w, e.detection.h)
+            for e in tube.entries
+            if e.detection is not None and not e.is_gap
+        ]
+        if not observed:
+            observed = [
+                (e.detection.cx, e.detection.cy, e.detection.w, e.detection.h)
+                for e in tube.entries
+                if e.detection is not None
+            ]
+        window = union_window(observed)
+
     for slot, entry in enumerate(tube.entries[:n]):
         det = entry.detection
         if det is None:
@@ -231,7 +248,10 @@ def crop_tube_patches(
         image = np.array(Image.open(frame.image_path).convert("RGB"))
         img_h, img_w, _ = image.shape
 
-        cx, cy, w, h = expand_bbox(det.cx, det.cy, det.w, det.h, context_factor)
+        box_src = window if stabilize else (det.cx, det.cy, det.w, det.h)
+        cx, cy, w, h = expand_bbox(
+            box_src[0], box_src[1], box_src[2], box_src[3], context_factor
+        )
         box = norm_bbox_to_pixel_square(cx, cy, w, h, img_w, img_h)
         patch_np = crop_and_resize(image, box, patch_size)
         patch_t = to_tensor(Image.fromarray(patch_np))  # CHW float32 [0,1]

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/model.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/model.py
@@ -233,6 +233,7 @@ class BboxTubeTemporalModel(TemporalModel):
                 max_frames=clf_cfg["max_frames"],
                 normalization_mean=mi["normalization"]["mean"],
                 normalization_std=mi["normalization"]["std"],
+                stabilize=mi.get("stabilize", False),
             )
             patches_per_tube.append(p.to(self._device))
             masks_per_tube.append(m.to(self._device))

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/model_input.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/model_input.py
@@ -11,6 +11,7 @@ import numpy as np
 from PIL import Image
 
 from .data import find_sequence_dir
+from .stabilize import union_window
 
 LABEL_TO_INT = {"fp": 0, "smoke": 1}
 
@@ -68,6 +69,7 @@ def process_tube(
     out_dir: Path,
     context_factor: float,
     patch_size: int,
+    stabilize: bool = False,
 ) -> None:
     record = json.loads(tube_path.read_text())
     sequence_id = record["sequence_id"]
@@ -80,11 +82,17 @@ def process_tube(
     seq_out = out_dir / sequence_id
     seq_out.mkdir(parents=True, exist_ok=True)
 
+    entries = record["tube"]["entries"]
+    window = None
+    if stabilize:
+        observed = [tuple(e["bbox"]) for e in entries if not e["is_gap"]]
+        window = union_window(observed or [tuple(e["bbox"]) for e in entries])
+
     frame_meta: list[dict] = []
-    for entry in record["tube"]["entries"]:
+    for entry in entries:
         frame_id = entry["frame_id"]
         frame_idx = entry["frame_idx"]
-        bbox = entry["bbox"]
+        bbox = window if stabilize else entry["bbox"]
         is_gap = entry["is_gap"]
 
         img_path = images_dir / f"{frame_id}.jpg"
@@ -103,7 +111,7 @@ def process_tube(
                 "frame_idx": frame_idx,
                 "frame_id": frame_id,
                 "is_gap": is_gap,
-                "orig_bbox": list(bbox),
+                "orig_bbox": list(entry["bbox"]),
                 "crop_bbox_pixels": list(crop_box),
                 "filename": filename,
             }
@@ -117,6 +125,7 @@ def process_tube(
         "num_frames": record["num_frames"],
         "context_factor": context_factor,
         "patch_size": patch_size,
+        "stabilize": stabilize,
         "frames": frame_meta,
     }
     (seq_out / "meta.json").write_text(json.dumps(meta, indent=2))

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/stabilize.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/stabilize.py
@@ -1,0 +1,26 @@
+"""Per-tube fixed crop window (pure geometry, no I/O).
+
+Stabilization is a crop-window decision, not a tube-building step. ``union_window``
+returns the enclosing box of a tube's observed detection boxes so the same region
+can be cropped from every frame — a static background with the smoke moving inside
+it. No context margin here: the crop step adds context via ``context_factor``.
+"""
+
+from __future__ import annotations
+
+
+def union_window(
+    boxes: list[tuple[float, float, float, float]],
+) -> tuple[float, float, float, float]:
+    """Enclosing box of ``boxes`` (each normalized ``(cx, cy, w, h)``).
+
+    Returns normalized ``(cx, cy, w, h)``. Raises ``ValueError`` if ``boxes`` is
+    empty. Width and height are computed independently from the x/y extents.
+    """
+    if not boxes:
+        raise ValueError("union_window requires at least one box")
+    x0 = min(cx - w / 2 for cx, _, w, _ in boxes)
+    y0 = min(cy - h / 2 for _, cy, _, h in boxes)
+    x1 = max(cx + w / 2 for cx, _, w, _ in boxes)
+    y1 = max(cy + h / 2 for _, cy, _, h in boxes)
+    return (x0 + x1) / 2, (y0 + y1) / 2, x1 - x0, y1 - y0

--- a/lib/bbox-tube-temporal/tests/test_inference_units.py
+++ b/lib/bbox-tube-temporal/tests/test_inference_units.py
@@ -670,3 +670,60 @@ class TestBuildTubesForInference:
             merge_max_gap=10,
         )
         assert len(tubes) == 2  # would be 1 if merge ran
+
+
+@pytest.fixture()
+def gradient_image_sequence(tmp_path: Path) -> list[Path]:
+    """Three identical 256x256 horizontal-gradient JPGs (spatial structure so a
+    different crop region yields different pixels)."""
+    col = np.linspace(0, 255, 256, dtype=np.uint8)
+    img = np.stack([np.tile(col, (256, 1))] * 3, axis=-1)
+    paths = []
+    for i in range(3):
+        p = tmp_path / f"grad_{i:02d}.jpg"
+        Image.fromarray(img).save(p, format="JPEG", quality=100)
+        paths.append(p)
+    return paths
+
+
+class TestCropTubePatchesStabilize:
+    def _tube_drifting(self):
+        return _tube(
+            0,
+            [
+                (0, _det(cx=0.3, cy=0.5, w=0.1, h=0.1)),
+                (1, _det(cx=0.5, cy=0.5, w=0.1, h=0.1)),
+                (2, _det(cx=0.7, cy=0.5, w=0.1, h=0.1)),
+            ],
+        )
+
+    def _crop(self, tube, frames, stabilize):
+        return crop_tube_patches(
+            tube,
+            frames,
+            context_factor=1.5,
+            patch_size=224,
+            max_frames=5,
+            normalization_mean=[0.485, 0.456, 0.406],
+            normalization_std=[0.229, 0.224, 0.225],
+            stabilize=stabilize,
+        )
+
+    def test_stabilized_crop_is_constant_across_frames(self, gradient_image_sequence):
+        frames = [
+            Frame(frame_id=p.stem, image_path=p, timestamp=None)
+            for p in gradient_image_sequence
+        ]
+        patches, _ = self._crop(self._tube_drifting(), frames, stabilize=True)
+        # One fixed window -> every real frame crops the same gradient region.
+        assert torch.equal(patches[0], patches[1])
+        assert torch.equal(patches[0], patches[2])
+
+    def test_per_frame_crop_varies_across_frames(self, gradient_image_sequence):
+        frames = [
+            Frame(frame_id=p.stem, image_path=p, timestamp=None)
+            for p in gradient_image_sequence
+        ]
+        patches, _ = self._crop(self._tube_drifting(), frames, stabilize=False)
+        # Boxes drift left->right across the gradient -> patches differ.
+        assert not torch.equal(patches[0], patches[2])

--- a/lib/bbox-tube-temporal/tests/test_model_input.py
+++ b/lib/bbox-tube-temporal/tests/test_model_input.py
@@ -177,3 +177,79 @@ def test_process_tube_uses_filename_from_raw_directory(tmp_path):
     meta = json.loads((out_dir / seq_id / "meta.json").read_text())
     assert meta["label"] == "fp"
     assert meta["label_int"] == 0
+
+
+def _write_tube_record_varying(path: Path, sequence_id: str, frame_ids: list[str]):
+    """Tube whose box drifts across frames (cx 0.3 -> 0.5 -> 0.7)."""
+    cxs = [0.3, 0.5, 0.7]
+    record = {
+        "sequence_id": sequence_id,
+        "split": "train",
+        "label": "smoke",
+        "source": "gt",
+        "num_frames": len(frame_ids),
+        "tube": {
+            "start_frame": 0,
+            "end_frame": len(frame_ids) - 1,
+            "entries": [
+                {
+                    "frame_idx": i,
+                    "frame_id": fid,
+                    "bbox": [cxs[i], 0.5, 0.05, 0.05],
+                    "is_gap": False,
+                    "confidence": 0.9,
+                }
+                for i, fid in enumerate(frame_ids)
+            ],
+        },
+    }
+    path.write_text(json.dumps(record))
+
+
+def test_process_tube_stabilize_uses_one_window_for_all_frames(tmp_path):
+    seq_id = "site_999_2023-05-23T17-18-31"
+    seq_root = tmp_path / "raw" / "wildfire" / seq_id / "images"
+    frame_ids = [f"{seq_id}_f{i}" for i in range(3)]
+    for fid in frame_ids:
+        _write_jpg(seq_root / f"{fid}.jpg", (255, 128, 64))
+    tube_path = tmp_path / "tubes" / f"{seq_id}.json"
+    tube_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_tube_record_varying(tube_path, seq_id, frame_ids)
+
+    out_dir = tmp_path / "out"
+    process_tube(
+        tube_path=tube_path,
+        raw_dir=tmp_path / "raw",
+        out_dir=out_dir,
+        context_factor=1.5,
+        patch_size=224,
+        stabilize=True,
+    )
+    meta = json.loads((out_dir / seq_id / "meta.json").read_text())
+    boxes = [f["crop_bbox_pixels"] for f in meta["frames"]]
+    assert boxes[0] == boxes[1] == boxes[2]  # one fixed window
+    assert meta["stabilize"] is True
+
+
+def test_process_tube_per_frame_box_varies_when_not_stabilized(tmp_path):
+    seq_id = "site_999_2023-05-23T17-18-32"
+    seq_root = tmp_path / "raw" / "wildfire" / seq_id / "images"
+    frame_ids = [f"{seq_id}_f{i}" for i in range(3)]
+    for fid in frame_ids:
+        _write_jpg(seq_root / f"{fid}.jpg", (255, 128, 64))
+    tube_path = tmp_path / "tubes" / f"{seq_id}.json"
+    tube_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_tube_record_varying(tube_path, seq_id, frame_ids)
+
+    out_dir = tmp_path / "out"
+    process_tube(
+        tube_path=tube_path,
+        raw_dir=tmp_path / "raw",
+        out_dir=out_dir,
+        context_factor=1.5,
+        patch_size=224,
+    )
+    meta = json.loads((out_dir / seq_id / "meta.json").read_text())
+    boxes = [f["crop_bbox_pixels"] for f in meta["frames"]]
+    assert boxes[0] != boxes[2]  # per-frame crop drifts
+    assert meta["stabilize"] is False

--- a/lib/bbox-tube-temporal/tests/test_stabilize.py
+++ b/lib/bbox-tube-temporal/tests/test_stabilize.py
@@ -1,0 +1,21 @@
+"""Unit tests for the pure stable-crop-window helper."""
+
+import pytest
+
+from bbox_tube_temporal.stabilize import union_window
+
+
+def test_union_of_two_boxes_is_axis_independent():
+    # A: x[0.15,0.25] y[0.45,0.55]; B: x[0.35,0.45] y[0.45,0.55]
+    # union: x[0.15,0.45] (w=0.3, cx=0.3); y[0.45,0.55] (h=0.1, cy=0.5)
+    boxes = [(0.2, 0.5, 0.1, 0.1), (0.4, 0.5, 0.1, 0.1)]
+    assert union_window(boxes) == pytest.approx((0.3, 0.5, 0.3, 0.1))
+
+
+def test_single_box_returns_itself():
+    assert union_window([(0.5, 0.5, 0.2, 0.2)]) == pytest.approx((0.5, 0.5, 0.2, 0.2))
+
+
+def test_empty_raises():
+    with pytest.raises(ValueError):
+        union_window([])


### PR DESCRIPTION
## What

Adds an **opt-in `stabilize` crop mode** to the bbox-tube temporal model. **Default is `false`** — this changes nothing in the existing pipeline; it adds a flag you can flip to experiment with stabilized crops here and in other projects.

Instead of cropping the drifting per-frame detection box from each frame, `stabilize: true` computes one fixed per-tube **union window** (the enclosing box of the tube's observed detections) and crops that same region from every frame — a static background with the smoke moving inside it.

## How it works

- `union_window(boxes)` — pure geometry helper in `lib/bbox-tube-temporal` (`stabilize.py`).
- Threaded through **both** crop paths behind a `stabilize` flag (default `False`):
  - `process_tube` (training PNG crops)
  - `crop_tube_patches` (inference crops)
- Baked into the packaged model config (`package_model._model_input_config`) so `predict()` crops the way it trained — train/inference parity. `mi.get("stabilize", False)` keeps every already-packaged model valid.
- Wired through `build_model_input --stabilize` and `dvc.yaml` from the `model_input.stabilize` param.

Default `stabilize=false` everywhere = byte-identical to today. Flip `model_input.stabilize: true` to opt in.

## Tests

- `lib`: `test_stabilize.py`, `test_model_input.py`, `test_inference_units.py` — **46 passed**.
- `experiment`: `test_build_model_input_script.py`, `test_package_model_script.py` — **5 passed**.

## A/B context (why it's opt-in, not the default)

A single-seed matched A/B on `vit_dinov2_finetune` (both arms retrained on current tubes, packaged + logistic-calibrated, val 318 seq) found stabilization **does not improve** the deployed operating point: at equal recall it went FP 2→4 and precision 0.987→0.974, with PR/ROC-AUC tied within noise. So this PR keeps the default off and lands the **machinery** for further cross-project verification — not a default switch.

_Config/feature only — no data or `dvc.lock` regen._
