### PR TITLE
Visualize stabilized crops in temporal-model-explorer

### DIFF
--- a/experiments/temporal-models/temporal-model-explorer/dvc.lock
+++ b/experiments/temporal-models/temporal-model-explorer/dvc.lock
@@ -17,8 +17,8 @@ stages:
     outs:
     - path: data/06_models
       hash: md5
-      md5: 52c855408125724b5db6f8d75640681d.dir
-      size: 325530344
+      md5: 7456c692e6af33debd6aa3ab1bee83f5.dir
+      size: 325530338
       nfiles: 2
   run_models:
     cmd: uv run python scripts/run_models.py --store data/03_primary/sequences 
@@ -31,8 +31,8 @@ stages:
       nfiles: 14012
     - path: data/06_models
       hash: md5
-      md5: 52c855408125724b5db6f8d75640681d.dir
-      size: 325530344
+      md5: 7456c692e6af33debd6aa3ab1bee83f5.dir
+      size: 325530338
       nfiles: 2
     - path: scripts/run_models.py
       hash: md5
@@ -53,10 +53,10 @@ stages:
     outs:
     - path: data/07_model_output/details
       hash: md5
-      md5: f9dd8b97d74e6d50bcfe65ed48d7e1ca.dir
-      size: 8941738
+      md5: 80aa72ee737034d9a5aac734042093f9.dir
+      size: 8019209
       nfiles: 1536
     - path: data/07_model_output/results.parquet
       hash: md5
-      md5: 11340ce7dccf5ab80448b248a0f45e11
-      size: 68719
+      md5: bf1e1fe15f10111cabb45cdc4c3890a9
+      size: 69388

--- a/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
+++ b/experiments/temporal-models/temporal-model-explorer/src/temporal_model_explorer/app.py
@@ -471,6 +471,9 @@ def _drilldown(key: str, model: str, row: pd.Series) -> None:  # pragma: no cove
     tubes_col.markdown(f"**tubes @ frame {i}** (context-cropped)")
     for tube in kept:
         at_frame = {idx: bbox for idx, bbox, _ in tube_input_boxes(tube, padded)}
+        # Stabilized variants crop a single fixed window (matching the classifier)
+        # for every frame, so the crop stays put instead of tracking the bbox.
+        stab_window = tube.get("stabilized_window")
         color = tube_color(tube["tube_id"])
         tprob = tube.get("probability")
         stat = (
@@ -486,10 +489,14 @@ def _drilldown(key: str, model: str, row: pd.Series) -> None:  # pragma: no cove
         else:
             trig_badge = ""
         chip = f"<b style='color:{color}'>● T{tube['tube_id']}</b>"
-        tubes_col.markdown(f"{chip} · {stat}{trig_badge}", unsafe_allow_html=True)
+        stab_note = " · 🔒 stabilized" if stab_window else ""
+        tubes_col.markdown(
+            f"{chip} · {stat}{trig_badge}{stab_note}", unsafe_allow_html=True
+        )
         if i in at_frame:
+            crop_box = tuple(stab_window) if stab_window else at_frame[i]
             tubes_col.image(
-                crop_around_bbox(seq_dir / meta.frames[i].file, at_frame[i]),
+                crop_around_bbox(seq_dir / meta.frames[i].file, crop_box),
                 width=220,
             )
         else:

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/details_schema.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/details_schema.py
@@ -34,6 +34,9 @@ class KeptTube(_Frozen):
     probability: float | None
     first_crossing_frame: int | None
     entries: list[TubeEntry]
+    # Fixed crop window (cx, cy, w, h) the classifier saw when stabilize=true;
+    # None for per-frame (non-stabilized) variants.
+    stabilized_window: tuple[float, float, float, float] | None = None
 
 
 class Preprocessing(_Frozen):

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/inference.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/inference.py
@@ -15,7 +15,7 @@ from torchvision.transforms.functional import to_tensor
 
 from .logistic_calibrator import LogisticCalibrator, extract_features
 from .model_input import crop_and_resize, expand_bbox, norm_bbox_to_pixel_square
-from .stabilize import union_window
+from .stabilize import tube_union_window
 from .tubes import (
     build_tubes,
     merge_colocated_tubes,
@@ -224,20 +224,7 @@ def crop_tube_patches(
     mean_t = torch.tensor(normalization_mean).view(3, 1, 1)
     std_t = torch.tensor(normalization_std).view(3, 1, 1)
 
-    window = None
-    if stabilize:
-        observed = [
-            (e.detection.cx, e.detection.cy, e.detection.w, e.detection.h)
-            for e in tube.entries
-            if e.detection is not None and not e.is_gap
-        ]
-        if not observed:
-            observed = [
-                (e.detection.cx, e.detection.cy, e.detection.w, e.detection.h)
-                for e in tube.entries
-                if e.detection is not None
-            ]
-        window = union_window(observed)
+    window = tube_union_window(tube.entries) if stabilize else None
 
     for slot, entry in enumerate(tube.entries[:n]):
         det = entry.detection
@@ -248,7 +235,7 @@ def crop_tube_patches(
         image = np.array(Image.open(frame.image_path).convert("RGB"))
         img_h, img_w, _ = image.shape
 
-        box_src = window if stabilize else (det.cx, det.cy, det.w, det.h)
+        box_src = window if window is not None else (det.cx, det.cy, det.w, det.h)
         cx, cy, w, h = expand_bbox(
             box_src[0], box_src[1], box_src[2], box_src[3], context_factor
         )

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/model.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/model.py
@@ -31,6 +31,7 @@ from .inference import (
 )
 from .logistic_calibrator import LogisticCalibrator, extract_features
 from .package import ModelPackage, load_model_package
+from .stabilize import tube_union_window
 from .tubes import build_tubes
 
 _PAD_STRATEGIES = {
@@ -310,6 +311,11 @@ class BboxTubeTemporalModel(TemporalModel):
                     probability=_probability_for(tube_idx, logits_list[tube_idx]),
                     first_crossing_frame=first_crossing,
                     entries=entries_models,
+                    stabilized_window=(
+                        tube_union_window(tube.entries)
+                        if mi.get("stabilize", False)
+                        else None
+                    ),
                 )
             )
 

--- a/lib/bbox-tube-temporal/src/bbox_tube_temporal/stabilize.py
+++ b/lib/bbox-tube-temporal/src/bbox_tube_temporal/stabilize.py
@@ -24,3 +24,30 @@ def union_window(
     x1 = max(cx + w / 2 for cx, _, w, _ in boxes)
     y1 = max(cy + h / 2 for _, cy, _, h in boxes)
     return (x0 + x1) / 2, (y0 + y1) / 2, x1 - x0, y1 - y0
+
+
+def tube_union_window(
+    entries,
+) -> tuple[float, float, float, float] | None:
+    """Stabilized crop window for a tube: union of its observed detection boxes.
+
+    ``entries`` are tube entries exposing ``.detection`` (with ``cx, cy, w, h``)
+    or ``None``, and ``.is_gap``. Prefers real (non-gap) detections; falls back
+    to any detection when every entry is a gap. Returns ``None`` if the tube has
+    no detections at all. The single source of truth for both the crop step and
+    the window reported in ``predict()`` details.
+    """
+    observed = [
+        (e.detection.cx, e.detection.cy, e.detection.w, e.detection.h)
+        for e in entries
+        if e.detection is not None and not e.is_gap
+    ]
+    if not observed:
+        observed = [
+            (e.detection.cx, e.detection.cy, e.detection.w, e.detection.h)
+            for e in entries
+            if e.detection is not None
+        ]
+    if not observed:
+        return None
+    return union_window(observed)

--- a/lib/bbox-tube-temporal/tests/test_model_edge_cases.py
+++ b/lib/bbox-tube-temporal/tests/test_model_edge_cases.py
@@ -342,11 +342,42 @@ class TestDeviceSelection:
             "probability",
             "first_crossing_frame",
             "entries",
+            "stabilized_window",
         }
         assert out.details["decision"]["trigger_tube_id"] == tube["tube_id"]
         assert isinstance(tube["entries"], list)
+        # Non-stabilized config -> no fixed window reported.
+        assert tube["stabilized_window"] is None
         entry = tube["entries"][0]
         assert set(entry.keys()) == {"frame_idx", "bbox", "is_gap", "confidence"}
+
+    def test_predict_details_report_stabilized_window_when_stabilizing(
+        self, tiny_classifier: TemporalSmokeClassifier, red_frames: list[Frame]
+    ) -> None:
+        """With ``model_input.stabilize=true`` each kept tube reports the fixed
+        union window the classifier cropped, so the explorer can show it."""
+        # Box drifts right across frames: x spans [0.25, 0.55], y fixed at 0.5.
+        per_frame = [
+            [(0.3 + 0.05 * i, 0.5, 0.1, 0.1, 0.9)] for i in range(len(red_frames))
+        ]
+        yolo = _fake_yolo_factory(per_frame)
+        cfg = {
+            **TEST_CONFIG,
+            "model_input": {**TEST_CONFIG["model_input"], "stabilize": True},
+        }
+        model = BboxTubeTemporalModel(
+            yolo_model=yolo, classifier=tiny_classifier, config=cfg, device="cpu"
+        )
+        out = model.predict(frames=red_frames)
+
+        kept = out.details["tubes"]["kept"]
+        assert len(kept) == 1
+        window = kept[0]["stabilized_window"]
+        assert window is not None
+        n = len(red_frames)
+        x0, x1 = 0.3 - 0.05, (0.3 + 0.05 * (n - 1)) + 0.05
+        expected = ((x0 + x1) / 2, 0.5, x1 - x0, 0.1)
+        assert tuple(window) == pytest.approx(expected)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_predict_on_cuda_runs_end_to_end(

--- a/lib/bbox-tube-temporal/tests/test_stabilize.py
+++ b/lib/bbox-tube-temporal/tests/test_stabilize.py
@@ -1,8 +1,20 @@
 """Unit tests for the pure stable-crop-window helper."""
 
+from types import SimpleNamespace
+
 import pytest
 
-from bbox_tube_temporal.stabilize import union_window
+from bbox_tube_temporal.stabilize import tube_union_window, union_window
+
+
+def _entry(box, is_gap=False):
+    """Duck-typed tube entry: ``.detection`` (cx,cy,w,h) or None, plus ``.is_gap``."""
+    det = (
+        None
+        if box is None
+        else SimpleNamespace(cx=box[0], cy=box[1], w=box[2], h=box[3])
+    )
+    return SimpleNamespace(detection=det, is_gap=is_gap)
 
 
 def test_union_of_two_boxes_is_axis_independent():
@@ -19,3 +31,26 @@ def test_single_box_returns_itself():
 def test_empty_raises():
     with pytest.raises(ValueError):
         union_window([])
+
+
+def test_tube_union_window_prefers_non_gap_detections():
+    # Two real detections + one gap (interpolated) box far to the right. The
+    # stabilized window must enclose only the non-gap boxes, ignoring the gap.
+    entries = [
+        _entry((0.2, 0.5, 0.1, 0.1)),
+        _entry((0.9, 0.5, 0.1, 0.1), is_gap=True),
+        _entry((0.4, 0.5, 0.1, 0.1)),
+    ]
+    assert tube_union_window(entries) == pytest.approx((0.3, 0.5, 0.3, 0.1))
+
+
+def test_tube_union_window_falls_back_to_any_detection_when_all_gaps():
+    entries = [
+        _entry((0.2, 0.5, 0.1, 0.1), is_gap=True),
+        _entry((0.4, 0.5, 0.1, 0.1), is_gap=True),
+    ]
+    assert tube_union_window(entries) == pytest.approx((0.3, 0.5, 0.3, 0.1))
+
+
+def test_tube_union_window_none_when_no_detections():
+    assert tube_union_window([_entry(None), _entry(None)]) is None


### PR DESCRIPTION
## What

The temporal-model-explorer always cropped tube patches around the **per-frame** detection bbox, so the stabilized model variant (`stabilize=true`) looked identical to the per-frame one — the crop window drifted frame-to-frame even though the classifier actually saw a single fixed (union-window) crop.

This surfaces the stabilization so it's visible in the viewer.

## Changes

**`lib/bbox-tube-temporal`**
- Add `stabilize.tube_union_window()` — the single source of truth for a tube's stabilized crop window (union of observed detection boxes, preferring non-gap entries; `None` if no detections).
- `crop_tube_patches()` now uses it (was inline), so the cropped region and the reported window can't drift apart.
- `predict()` records it per kept tube as `KeptTube.stabilized_window` (`None` for non-stabilized variants).

**`experiments/temporal-models/temporal-model-explorer`**
- When a kept tube reports a `stabilized_window`, the drilldown crops every frame around that fixed window instead of the per-frame bbox, and badges the tube `🔒 stabilized`.

## Tests
- New unit tests for `tube_union_window` (non-gap preference, all-gap fallback, no-detections → None).
- New `predict()` test asserting `stabilized_window` is populated when stabilizing and `None` otherwise.
- Full `bbox-tube-temporal` suite green (183 passed).

## Note
Details JSON for the `platform` (alert-api) and `pyro-annotator` sources were re-scored locally so each kept tube now carries `stabilized_window`. DVC data/`dvc.lock` are managed/pushed separately.